### PR TITLE
Adapt and fix tests for Ceph Luminous and tooling changes 

### DIFF
--- a/HACKING.txt
+++ b/HACKING.txt
@@ -8,13 +8,12 @@ the platform code as well:
 
     local$ ssh hydra01.fcio.net
     hydra01 ~ $ cd fc-nixos
-    hydra01 ~/fc-nixos $ eval $(./dev-setup)
-    hydra01 ~/fc-nixos $ cd ../fc.qemu
-    hydra01 ~/fc.qemu $ nix-build --arg useCheckout true tests/kvm_host.nix
+    hydra01 ~/fc-nixos $ nix-shell
+    hydra01 ~/fc-nixos $ nix-build --arg useCheckout true tests/kvm_host.nix
 
 To run only some tests you can pass arguments to pytest:
 
-    hydra01 ~/fc.qemu $ nix-build --arg useCheckout true --argstr testOpts "-k test_agent_check"  tests/kvm_host.nix
+    hydra01 ~/fc-nixos $ nix-build --arg useCheckout true --argstr testOpts "-k test_agent_check"  tests/kvm_host.nix
 
 Real-world testing on FCIO DEV network
 --------------------------------------

--- a/src/fc/qemu/hazmat/tests/test_volume.py
+++ b/src/fc/qemu/hazmat/tests/test_volume.py
@@ -130,6 +130,8 @@ def test_force_unlock(volume):
     assert volume.lock_status() is None
 
 
+# increase timeout from the default of 3s
+@pytest.mark.timeout(6)
 def test_volume_mkswap(volume):
     volume.ensure_presence()
     volume.ensure_size(5 * 1024 ** 2)

--- a/src/fc/qemu/tests/qemu_test.py
+++ b/src/fc/qemu/tests/qemu_test.py
@@ -65,6 +65,8 @@ def test_proc_empty_pidfile(qemu_with_pidfile):
 
 
 def test_proc_pidfile_with_garbage(qemu_with_pidfile):
+    """pidfiles are allowed to contain trailing lines with garbage,
+    process retrieval must still work then."""
     with open(qemu_with_pidfile.pidfile, "a") as f:
         f.write("trailing line\n")
     assert isinstance(qemu_with_pidfile.proc(), psutil.Process)

--- a/src/fc/qemu/tests/vm_test.py
+++ b/src/fc/qemu/tests/vm_test.py
@@ -490,7 +490,7 @@ ensure-throttle action=none current_iops=10 device=virtio2 machine=simplevm targ
     )
 
 
-@pytest.mark.timeout(60)
+@pytest.mark.timeout(80)
 @pytest.mark.live
 def test_vm_resize_disk(vm):
     vm.start()
@@ -558,7 +558,7 @@ def kill_vms():
 
 
 @pytest.mark.live
-@pytest.mark.timeout(120)
+@pytest.mark.timeout(180)
 def test_vm_migration(vm, kill_vms):
     def call(cmd, wait=True, host=None):
         for ssh_cmd in ["scp", "ssh"]:


### PR DESCRIPTION
Changes in the surroundig tooling used with fc.qemu require adapting the integration tests.

- Differing output of `rbd ls` in Ceph Luminous or Jewel required unifying the output of `fc-create-vm`, a tool used in vm tests.
- Some tests appeared to be flaky under load, slightly missing their timeouts
- small fix for testing instructions

**Security considerations**:  
This does not change any of the actual working code of fc.qemu and only adapts the test code to changed tooling used together with fc.qemu.  
Some test timeouts have been modified, if they have been set to exact values intentionally instead of arbitrarily picking timeouts then the tests might have become too loose.  
The line
`qmp_capabilities arguments={} id=None machine=simplevm subsystem=qemu/qmp`
is allowed to appear once **or** multiple times in the vm test output. I assumed that this is not problematic to the correctness of the test and thus the availabilty of the service provided by fc.qemu.

Done as part of PL-130693.