### PR TITLE
tests/hazmat: fix signature of mocked ImageBusy exception

### DIFF
--- a/src/fc/qemu/hazmat/conftest.py
+++ b/src/fc/qemu/hazmat/conftest.py
@@ -1,4 +1,4 @@
-import os
+import os, errno
 
 import pytest
 import rados
@@ -109,7 +109,7 @@ class ImageMock(object):
         else:
             assert lock["exclusive"]
             if not lock["lockers"][0][1] == cookie:
-                raise rbd.ImageBusy()
+                raise rbd.ImageBusy(errno.EBUSY, "Image is busy")
             return
         raise RuntimeError("unsupported mock path")
 


### PR DESCRIPTION
After fixing version impurities in fc-nixos, the locking unit test failed:

```
_____________________________ test_volume_locking ______________________________
Traceback (most recent call last):
  File "/nix/store/grmmiaa7y3i68jp3hmwdnlx0c5k6c8yb-python-2.7.18-env/lib/python2.7/site-packages/fc/qemu/hazmat/tests/test_volume.py", line 119, in test_volume_locking
    volume.lock()
  File "/nix/store/grmmiaa7y3i68jp3hmwdnlx0c5k6c8yb-python-2.7.18-env/lib/python2.7/site-packages/fc/qemu/hazmat/volume.py", line 247, in lock
    self.rbdimage.lock_exclusive(self.ceph.CEPH_LOCK_HOST)
  File "/nix/store/grmmiaa7y3i68jp3hmwdnlx0c5k6c8yb-python-2.7.18-env/lib/python2.7/site-packages/fc/qemu/hazmat/conftest.py", line 112, in lock_exclusive
    raise rbd.ImageBusy()
  File "rbd.pyx", line 393, in rbd.OSError.__init__
TypeError: __init__() takes at least 2 positional arguments (1 given)
```

It turned out that the mocked ImageBusy exception was initialised with the wrong signature, so this was a bug in the test mocking and not the actual fc-qemu or even librbdpy code.