### PR TITLE
Fix type error in guestagent write_file, causing mark-qemu-binary-generation to fail

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,8 +21,8 @@ repos:
     id: isort
     name: isort (python)
   repo: https://github.com/pycqa/isort
-  rev: 5.10.1
+  rev: 5.12.0
 - hooks:
   - id: black
   repo: https://github.com/psf/black
-  rev: 22.12.0
+  rev: 22.3.0

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,8 +1,15 @@
 Release notes
 =============
 
-1.3.0 (not released yet)
-------------------------
+1.3.1 (2023-02-03)
+------------------
+
+- fix regression in guestagent Qemu.write_file, causing the
+  mark-qemu-binary-generation calls to fail
+- improve guestagent test coverage and mocking
+
+1.3.0 (2023-01-17)
+------------------
 
 - porting to python3
 - Ceph Nautilus compatibility

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ with open("HACKING.txt") as f:
 
 setup(
     name="fc.qemu",
-    version="1.3.0.dev0",
+    version="1.3.1.dev0",
     author="Christian Kauhaus, Christian Theune",
     author_email="mail@flyingcircus.io",
     url="http://github.com/flyingcircusio/fc.qemu",

--- a/src/fc/qemu/hazmat/conftest.py
+++ b/src/fc/qemu/hazmat/conftest.py
@@ -1,12 +1,16 @@
 import errno
 import os
+import tempfile
+import typing
 
+import mock
 import pytest
 import rados
 import rbd
 
 from . import volume
 from .ceph import Ceph
+from .guestagent import GuestAgent
 
 
 class RadosMock(object):
@@ -247,3 +251,46 @@ def ceph_inst(ceph_mock):
         yield ceph
     finally:
         ceph.__exit__(None, None, None)
+
+
+@pytest.fixture
+def guest_agent(monkeypatch, tmpdir):
+    guest_agent = GuestAgent("testvm", 0.1)
+
+    class ClientStub(object):
+        timeout: int = 0
+        messages_sent: typing.List[bytes]
+        responses: typing.List[str]
+
+        def __init__(self):
+            self.messages_sent = []
+            self.responses = []
+
+        def settimeout(self, timeout):
+            self.timeout = timeout
+
+        def connect(self, address):
+            pass
+
+        def close(self):
+            pass
+
+        def send(self, msg: bytes):
+            self.messages_sent.append(msg)
+
+        def makefile(self):
+            pseudo_socket_filename = tempfile.mktemp(dir=tmpdir)
+            with open(pseudo_socket_filename, "w") as f:
+                f.write("\n".join(self.responses))
+            return open(pseudo_socket_filename)
+
+    client_stub = ClientStub()
+
+    guest_agent.client_factory = lambda family, type: client_stub
+    guest_agent._client_stub = client_stub
+
+    # Ensure guest agent sync ids are stable.
+    randint = mock.Mock(return_value=87643)
+    monkeypatch.setattr("random.randint", randint)
+
+    return guest_agent

--- a/src/fc/qemu/hazmat/guestagent.py
+++ b/src/fc/qemu/hazmat/guestagent.py
@@ -13,11 +13,13 @@ class ClientError(RuntimeError):
 class GuestAgent(object):
     """Wraps qemu guest agent wire protocol."""
 
-    def __init__(self, machine, timeout):
+    def __init__(self, machine, timeout, client_factory=socket.socket):
         self.machine = machine
         self.timeout = timeout
         self.log = log.bind(machine=machine)
         self.file = None
+
+        self.client_factory = client_factory
         self.client = None
 
     def read(self):
@@ -82,7 +84,7 @@ class GuestAgent(object):
         )
 
     def __enter__(self):
-        self.client = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        self.client = self.client_factory(socket.AF_UNIX, socket.SOCK_STREAM)
         self.client.settimeout(self.timeout)
         self.client.connect("/run/qemu.{}.gqa.sock".format(self.machine))
         self.file = self.client.makefile()

--- a/src/fc/qemu/hazmat/guestagent.py
+++ b/src/fc/qemu/hazmat/guestagent.py
@@ -31,7 +31,10 @@ class GuestAgent(object):
         return result["return"]
 
     def cmd(self, cmd, flush_ga_parser=False, timeout=None, **args):
-        """Issues GA command and returns the result."""
+        """Issues GA command and returns the result.
+        All **args need to be serialisable to JSON, that implies that `bytes` are *not*
+        valid.
+        """
         message = json.dumps({"execute": cmd, "arguments": args})
         message = message.encode("ascii")
         if flush_ga_parser:

--- a/src/fc/qemu/hazmat/qemu.py
+++ b/src/fc/qemu/hazmat/qemu.py
@@ -411,7 +411,9 @@ class Qemu(object):
                 guest.cmd(
                     "guest-file-write",
                     handle=handle,
-                    **{"buf-b64": encode(content, "base64")},
+                    # The ASCII armour needs to be turned into text again, because the
+                    # JSON encoder doesn't handle bytes-like objects.
+                    **{"buf-b64": encode(content, "base64").decode("ascii")},
                 )
                 guest.cmd("guest-file-close", handle=handle)
             except ClientError:

--- a/src/fc/qemu/hazmat/tests/guestagent_test.py
+++ b/src/fc/qemu/hazmat/tests/guestagent_test.py
@@ -1,82 +1,60 @@
 import io
-import socket
 
-import mock
 import pytest
 
-from ..guestagent import ClientError, GuestAgent
+from ..guestagent import ClientError
 
 
-@pytest.fixture
-def ga(monkeypatch):
-    ga = GuestAgent("testvm", 0.1)
-    ga.file = io.StringIO()
-    ga.client = mock.MagicMock()
-    randint = mock.Mock(return_value=87643)
-    monkeypatch.setattr("random.randint", randint)
-    return ga
+def test_ga_read(guest_agent):
+    guest_agent.file = io.StringIO('{"return": 17035}\n')
+    assert 17035 == guest_agent.read()
 
 
-def test_ga_read(ga):
-    ga.file = io.StringIO('{"return": 17035}\n')
-    assert 17035 == ga.read()
-
-
-def test_ga_read_error(ga):
-    ga.file = io.StringIO('{"return": 0, "error": "test failure"}\n')
+def test_ga_read_error(guest_agent):
+    guest_agent.file = io.StringIO('{"return": 0, "error": "test failure"}\n')
     with pytest.raises(ClientError):
-        ga.read()
+        guest_agent.read()
 
 
-def test_ga_sync_immediate(ga):
-    ga.file = io.StringIO('{"return": 87643}\n')
-    ga.sync()
-    assert True
+def test_ga_sync_immediate(guest_agent):
+    guest_agent._client_stub.responses = [
+        '{"return": 87643}',
+    ]
+
+    with guest_agent:
+        # This causes an implicit sync and wires up the client stub.
+        assert guest_agent.file.fileno()
+        assert guest_agent.client is not None
+
+    assert guest_agent.client.messages_sent == [
+        b'\xff{"execute": "guest-sync", "arguments": {"id": 87643}}'
+    ]
 
 
-def test_ga_sync_retry(ga):
-    ga.file = io.StringIO('{"return": 2}\n{"return": 87643}\n')
-    ga.sync()
-    assert True
+def test_ga_sync_retry(guest_agent):
+    guest_agent._client_stub.responses = [
+        '{"return": 2}',
+        '{"return": 87643}',
+    ]
+
+    with guest_agent:
+        # This causes an implicit sync and wires up the client stub.
+        assert True
+
+    assert guest_agent.client.messages_sent == [
+        b'\xff{"execute": "guest-sync", "arguments": {"id": 87643}}'
+    ]
 
 
-def test_ga_sync_too_often(ga):
-    ga.file = io.StringIO(
-        """\
-{"return": 2}
-{"return": 3}
-{"return": 4}
-{"return": 4}
-{"return": 4}
-{"return": 4}
-{"return": 4}
-{"return": 4}
-{"return": 4}
-{"return": 4}
-{"return": 4}
-{"return": 4}
-{"return": 4}
-{"return": 4}
-{"return": 4}
-{"return": 4}
-{"return": 4}
-{"return": 4}
-{"return": 4}
-{"return": 4}
-{"return": 4}
-{"return": 4}
-{"return": 87643}
-"""
-    )
+def test_ga_sync_too_often(guest_agent):
+    guest_agent._client_stub.responses = [
+        f'{{"return": {x}}}' for x in range(20)
+    ]
+
     with pytest.raises(ClientError):
-        ga.sync()
+        with guest_agent:
+            pass
 
-
-def test_ga_contextmgr(ga, monkeypatch, tmpdir):
-    monkeypatch.setattr(socket, "socket", mock.MagicMock(socket.socket))
-    with open(str(tmpdir / "socket"), "w") as f:
-        f.write('{"return": 87643}\n')
-    f = open(str(tmpdir / "socket"), "r")
-    socket.socket().makefile.return_value = f
-    with ga as g:
-        assert g.machine == "testvm"
+    assert guest_agent.client.messages_sent == [
+        b'\xff{"execute": "guest-sync", "arguments": {"id": 87643}}'
+    ]

--- a/src/fc/qemu/hazmat/tests/test_qemu.py
+++ b/src/fc/qemu/hazmat/tests/test_qemu.py
@@ -1,0 +1,40 @@
+import pytest
+
+from fc.qemu.hazmat.qemu import Qemu
+
+
+def test_write_file_expects_bytes(guest_agent):
+    qemu = Qemu({"name": "vm00", "id": 2345})
+    qemu.guestagent = guest_agent
+    with pytest.raises(TypeError):
+        qemu.write_file("/tmp/foo", '"asdf"')
+
+
+def test_write_file_no_error(guest_agent):
+    # We do't have access to a real guest agent here
+    # but we saw errors even encoding the data to the socket.
+    qemu = Qemu({"name": "vm00", "id": 2345})
+    # the emulated answers of the guest agent:
+
+    guest_agent._client_stub.responses = [
+        # sync ID, hard-coded in fixture
+        '{"return": 87643}',
+        # emulated non-empty result of executions:
+        # guest-file-open
+        '{"return": "file-handle-1"}',
+        # guest-file-write
+        '{"return": "qwer"}',
+        # guest-file-close
+        '{"return": "zuio"}',
+    ]
+
+    qemu.guestagent = guest_agent
+
+    qemu.write_file("/tmp/foo", b'"asdf"')
+    print(guest_agent.client.messages_sent)
+    assert guest_agent.client.messages_sent == [
+        b'\xff{"execute": "guest-sync", "arguments": {"id": 87643}}',
+        b'{"execute": "guest-file-open", "arguments": {"path": "/tmp/foo", "mode": "w"}}',
+        b'{"execute": "guest-file-write", "arguments": {"handle": "file-handle-1", "buf-b64": "ImFzZGYi\\n"}}',
+        b'{"execute": "guest-file-close", "arguments": {"handle": "file-handle-1"}}',
+    ]


### PR DESCRIPTION
Fixes a regression in mark-qemu-binary-generation, covers that regression with new unit tests, and refactors the mocking for existing guestagent tests.

Also bumbs the version to 1.3.1 (needs to be tagged after merge).

## Security implications

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - [x] discovered regression needs to be fixed
  - [x] the fix must not introduce further regressions
  - [x] investigate how the regression had not been discovered by a test before 
- [x] Security requirements tested? (EVIDENCE)
  - [x] regression is fixed, verified by manual testing in the dev cluster
  - [x] unit test have been extended to cover the core code path part of that regression
  - [x] unit tests pass 