### PR TITLE
disable the writeback cache

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,8 +4,7 @@ Release notes
 1.4.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
-
+- Disable the writeback cache (DIR-919)
 
 1.4.2 (2023-12-15)
 ------------------

--- a/src/fc/qemu/agent.py
+++ b/src/fc/qemu/agent.py
@@ -1516,7 +1516,6 @@ class Agent(object):
         self.qemu.config = tpl.format(
             accelerator=accelerator,
             machine_type=machine_type,
-            disk_cache_mode=self.qemu.disk_cache_mode,
             network="".join(netconfig),
             **self.cfg,
         )

--- a/src/fc/qemu/hazmat/qemu.py
+++ b/src/fc/qemu/hazmat/qemu.py
@@ -146,17 +146,6 @@ class Qemu(object):
         ]:
             setattr(self, f, getattr(self, f).format(**vm_cfg))
 
-        # prepare qemu-specific config settings
-        self.qemu_cfg = self.cfg.get("qemu", {})
-
-        # The default if nothing is set is to enable "writeback" for backwards
-        # compatability: before introducing this option everything used
-        # writeback.
-        if self.qemu_cfg.get("write_back_cache", True):
-            self.disk_cache_mode = "writeback"
-        else:
-            self.disk_cache_mode = "none"
-
         # We are running qemu with chroot which causes us to not be able to
         # resolve names. :( See #13837.
         a = self.migration_address.split(":")

--- a/src/fc/qemu/qemu.vm.cfg.in
+++ b/src/fc/qemu/qemu.vm.cfg.in
@@ -20,7 +20,7 @@
   format = "rbd"
   file = "rbd:{rbd_pool}/{name}.root:id={{ceph_id}}"
   aio = "threads"
-  cache = "{disk_cache_mode}"
+  cache = "none"
 
 [drive]
   index = "1"
@@ -29,7 +29,7 @@
   format = "rbd"
   file = "rbd:{rbd_pool}/{name}.swap:id={{ceph_id}}"
   aio = "threads"
-  cache = "{disk_cache_mode}"
+  cache = "none"
 
 [drive]
   index = "2"
@@ -38,7 +38,7 @@
   format = "rbd"
   file = "rbd:{rbd_pool}/{name}.tmp:id={{ceph_id}}"
   aio = "threads"
-  cache = "{disk_cache_mode}"
+  cache = "none"
 
 [device]
   driver = "virtio-rng-pci"

--- a/src/fc/qemu/tests/qemu_test.py
+++ b/src/fc/qemu/tests/qemu_test.py
@@ -72,23 +72,3 @@ def test_proc_pidfile_with_garbage(qemu_with_pidfile):
     with open(qemu_with_pidfile.pidfile, "a") as f:
         f.write("trailing line\n")
     assert isinstance(qemu_with_pidfile.proc(), psutil.Process)
-
-
-def test_disk_cache_mode_default_writeback():
-    q = Qemu(dict(name="testvm", id=1234))
-    assert q.disk_cache_mode == "writeback"
-
-
-def test_disk_cache_mode_default_writeback2():
-    q = Qemu(dict(name="testvm", id=1234, qemu=dict()))
-    assert q.disk_cache_mode == "writeback"
-
-
-def test_disk_cache_mode_enc_enabled():
-    q = Qemu(dict(name="testvm", id=1234, qemu=dict(write_back_cache=True)))
-    assert q.disk_cache_mode == "writeback"
-
-
-def test_disk_cache_mode_enc_disabled():
-    q = Qemu(dict(name="testvm", id=1234, qemu=dict(write_back_cache=False)))
-    assert q.disk_cache_mode == "none"


### PR DESCRIPTION
DIR-919

manually ran `tests/kvm_host_ceph-nautilus.nix` on hydra01.