### PR TITLE
Add cloud-init compatibility for Ubuntu VMs

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -18,6 +18,10 @@ Release notes
 
 - rbd: fix cluster load issue due to overuse of rbd.list (PL-133194)
 
+- Add support for cloud-init ubuntu VMs (PL-133325, PL-133372)
+  Add cloud-init `cidata` volume unconditionally for all VMs.
+  Sync SSH root keys for ubuntu VMs via qmp in ensure.
+
 1.6 (2024-10-23)
 ----------------
 

--- a/HACKING.txt
+++ b/HACKING.txt
@@ -14,6 +14,12 @@ host1 $ sudo -i
 host1 $ run-tests
 ```
 
+If your Ceph setup becomes unclean/stuck, you can reboot `host1` or run (without rebooting):
+
+```
+fc.qemu $ cleanup-ceph
+```
+
 ## Hydra integration tests
 
 We assume that you have a local checkout on your machine for editing and that

--- a/batou/components/ceph/ceph.nix
+++ b/batou/components/ceph/ceph.nix
@@ -33,6 +33,21 @@ in
     ''
   );
 
+  environment.systemPackages = [
+    (pkgs.writeShellScriptBin "cleanup-ceph" ''
+      systemctl stop fc-ceph-mon
+      systemctl stop fc-ceph-mgr
+      systemctl stop fc-ceph-osd@0.service
+      umount /srv/ceph/mgr/ceph-host1
+      umount /srv/ceph/mon/ceph-host1
+      umount /srv/ceph/osd/ceph-0
+      vgremove vgjnl00 -y
+      vgremove vgosd-0 -y
+      losetup -D
+      rm -rf /ceph
+    '')
+  ];
+
   # Try to disable as many cronjobs as possible as they're really just in the
   # way in the test suite.
   systemd.timers.fc-ceph-load-vm-images.enable = lib.mkForce false;

--- a/batou/components/nixos/base.nix
+++ b/batou/components/nixos/base.nix
@@ -12,13 +12,13 @@ in
   flyingcircus.encServices = [
     {
       address = "host1";
-      ips = [ "10.12.0.6" ];
+      ips = [ "{{component.host1_addr.listen.host}}" ];
       location = "test";
       service = "consul_server-server";
     }
     {
       address = "host1";
-      ips = [ "10.12.0.6" ];
+      ips = [ "{{component.host1_addr.listen.host}}" ];
       location = "test";
       service = "ceph_mon-mon";
     }
@@ -28,8 +28,8 @@ in
   flyingcircus.agent.enable = lib.mkForce false;
 
   networking.extraHosts = ''
-    10.12.0.6 host1.srv.test.gocept.net host1
-    10.12.0.10 host2.srv.test.gocept.net host2
+    {{component.host1_addr.listen.host}} host1.srv.test.gocept.net host1
+    {{component.host2_addr.listen.host}} host2.srv.test.gocept.net host2
   '';
 
   flyingcircus.static.ceph.fsids.test.test = "d118a9a4-8be5-4703-84c1-87eada2e6b60";

--- a/batou/components/nixos/component.py
+++ b/batou/components/nixos/component.py
@@ -1,9 +1,9 @@
-import copy
 import json
 from pathlib import Path
 
 from batou.component import Attribute, Component
 from batou.lib.file import File
+from batou.utils import Address
 
 
 def update_merge(d1, d2):
@@ -106,6 +106,9 @@ class NixOS(Component):
                 + list(self.require("enc", host=self.host, reverse=True)),
             )
         )
+
+        self.host1_addr = Address("host1:0")
+        self.host2_addr = Address("host2:0")
         self += (base := File("/etc/local/nixos/base.nix"))
 
         # Those snippets would typically be File components that place

--- a/batou/requirements.lock
+++ b/batou/requirements.lock
@@ -1,11 +1,11 @@
-# appenv-requirements-hash: 321a85f3cca3708589ef9487aa8e2403345281bb657f3288f35de49fd8445c34
+# appenv-requirements-hash: 0f98d78663247bfc02f531ad77e13cfb0763670829589f50c845e929fcb70c8b
 ConfigUpdater==3.2
-Jinja2==3.1.5
+Jinja2==3.1.6
 MarkupSafe==3.0.2
 PyYAML==6.0.2
-batou @ https://github.com/flyingcircusio/batou/archive/bb4e10033dbac7cf6345bc2a3e6d3f52e6a736aa.zip#sha256=3a4b804a8574d3418082f6dad94444dafd4b62b2188b66fa002b5637bd54031f
+batou @ https://github.com/flyingcircusio/batou/archive/f99d8dd9604edc336f7ae4424f751373c2db2ce9.zip#sha256=c5c1855c9ea96d82e1bb0275152077cfe2d47be32d159205de768bb4e007827b
 
-certifi==2024.12.14
+certifi==2025.1.31
 charset-normalizer==3.4.1
 execnet==2.1.1
 idna==3.10
@@ -14,6 +14,6 @@ importlib_resources==6.5.2
 py==1.11.0
 remote-pdb==2.1.0
 requests==2.32.3
-setuptools==75.8.0
+setuptools==76.1.0
 urllib3==2.3.0
 zipp==3.21.0

--- a/batou/requirements.txt
+++ b/batou/requirements.txt
@@ -1,2 +1,2 @@
-batou @ https://github.com/flyingcircusio/batou/archive/bb4e10033dbac7cf6345bc2a3e6d3f52e6a736aa.zip#sha256=3a4b804a8574d3418082f6dad94444dafd4b62b2188b66fa002b5637bd54031f
+batou @ https://github.com/flyingcircusio/batou/archive/f99d8dd9604edc336f7ae4424f751373c2db2ce9.zip#sha256=c5c1855c9ea96d82e1bb0275152077cfe2d47be32d159205de768bb4e007827b
 # batou>=2.4.1

--- a/src/fc/qemu/agent.py
+++ b/src/fc/qemu/agent.py
@@ -1151,7 +1151,7 @@ class Agent(object):
             self.log.error("mark-qemu-binary-generation", reason=str(e))
 
     def update_root_ssh_keys_cloudinit(self):
-        if self.cfg["environment_class_type"] != 'cloudinit':
+        if self.cfg["environment_class_type"] != "cloudinit":
             return
         self.log.info("update-root-ssh-keys-cloudinit")
         try:
@@ -1163,9 +1163,7 @@ class Agent(object):
                 "/root/.ssh/authorized_keys_fc",
                 to_write_text.encode("utf-8"),
             )
-            self.qemu.exec(
-                "chmod", ["0600", "/root/.ssh/authorized_keys_fc"]
-            )
+            self.qemu.exec("chmod", ["0600", "/root/.ssh/authorized_keys_fc"])
         except Exception as e:
             self.log.error("update-root-ssh-keys-cloudinit", reason=str(e))
 

--- a/src/fc/qemu/agent.py
+++ b/src/fc/qemu/agent.py
@@ -1151,8 +1151,7 @@ class Agent(object):
             self.log.error("mark-qemu-binary-generation", reason=str(e))
 
     def update_root_ssh_keys_cloudinit(self):
-        # TODO: use environment_class_type != 'cloudinit'
-        if self.cfg["environment_class"].lower() != "ubuntu":
+        if self.cfg["environment_class_type"] != 'cloudinit':
             return
         self.log.info("update-root-ssh-keys-cloudinit")
         try:
@@ -1163,6 +1162,9 @@ class Agent(object):
             self.qemu.write_file(
                 "/root/.ssh/authorized_keys_fc",
                 to_write_text.encode("utf-8"),
+            )
+            self.qemu.exec(
+                "chmod", ["0600", "/root/.ssh/authorized_keys_fc"]
             )
         except Exception as e:
             self.log.error("update-root-ssh-keys-cloudinit", reason=str(e))

--- a/src/fc/qemu/agent.py
+++ b/src/fc/qemu/agent.py
@@ -331,6 +331,14 @@ class Agent(object):
     def lock_file(self):
         return self.prefix / "run" / f"qemu.{self.name}.lock"
 
+    @property
+    def users_file(self):
+        return (
+            self.prefix
+            / "etc/qemu/users"
+            / f"{self.cfg['resource_group']}.json"
+        )
+
     def _load_enc(self):
         try:
             with self.config_file.open() as f:
@@ -346,6 +354,10 @@ class Agent(object):
                 raise VMConfigNotFound(
                     "Could not load {}".format(self.config_file)
                 )
+
+    def _load_users(self):
+        with self.users_file.open() as f:
+            return json.load(f)
 
     @classmethod
     def handle_consul_event(cls, input: typing.TextIO = sys.stdin):
@@ -900,6 +912,7 @@ class Agent(object):
         self.cfg["root_size"] = self.cfg["disk"] * (1024**3)
         self.cfg["swap_size"] = swap_size(self.cfg["memory"])
         self.cfg["tmp_size"] = tmp_size(self.cfg["disk"])
+        self.cfg["cidata_size"] = 10 * MiB
         self.cfg["ceph_id"] = self.ceph_id
         self.cfg["cpu_model"] = self.cfg.get("cpu_model", "qemu64")
         self.cfg["binary_generation"] = self.binary_generation
@@ -1092,6 +1105,7 @@ class Agent(object):
             self.ensure_thawed()
             self.mark_qemu_binary_generation()
             self.mark_qemu_guest_properties()
+            self.update_root_ssh_keys_cloudinit()
 
     def cleanup(self):
         """Removes various run and tmp files."""
@@ -1135,6 +1149,23 @@ class Agent(object):
             )
         except Exception as e:
             self.log.error("mark-qemu-binary-generation", reason=str(e))
+
+    def update_root_ssh_keys_cloudinit(self):
+        # TODO: use environment_class_type != 'cloudinit'
+        if self.cfg["environment_class"].lower() != "ubuntu":
+            return
+        self.log.info("update-root-ssh-keys-cloudinit")
+        try:
+            users = self._load_users()
+            to_write_text = util.generate_cloudinit_ssh_keyfile(
+                users, self.cfg["resource_group"]
+            )
+            self.qemu.write_file(
+                "/root/.ssh/authorized_keys_fc",
+                to_write_text.encode("utf-8"),
+            )
+        except Exception as e:
+            self.log.error("update-root-ssh-keys-cloudinit", reason=str(e))
 
     def ensure_online_disk_size(self):
         """Trigger block resize action for the root disk."""

--- a/src/fc/qemu/default.conf
+++ b/src/fc/qemu/default.conf
@@ -28,3 +28,4 @@ lock_host = localhost
 create-vm = create-vm -I {rbd_pool} {name}
 mkfs-xfs = -q -f -K -m crc=1,finobt=1 -d su=4m,sw=1
 mkfs-ext4 = -q -m 1 -E nodiscard
+mkfs-vfat =

--- a/src/fc/qemu/hazmat/ceph.py
+++ b/src/fc/qemu/hazmat/ceph.py
@@ -7,16 +7,21 @@ import hashlib
 import ipaddress
 import json
 import os
+import xmlrpc.client
 from pathlib import Path
 from typing import Dict, Optional
 
 import rados
 import rbd
 import yaml
-import xmlrpc.client
 
 import fc.qemu.directory
-from fc.qemu.util import generate_cloudinit_ssh_keyfile, inplace_update, conditional_update
+from fc.qemu.util import (
+    conditional_update,
+    generate_cloudinit_ssh_keyfile,
+    inplace_update,
+)
+
 from ..sysconfig import sysconfig
 from ..timeout import TimeoutError
 from ..util import cmd, log, parse_export_format
@@ -399,9 +404,7 @@ class CloudInitSpec(VolumeSpecification):
 
         ssh_authorized_keys_content = ""
         try:
-            with Path(
-                f"/etc/qemu/users/{rg}.json"
-            ).open() as f:
+            with Path(f"/etc/qemu/users/{rg}.json").open() as f:
                 users = json.load(f)
                 ssh_authorized_keys_content = generate_cloudinit_ssh_keyfile(
                     users, rg

--- a/src/fc/qemu/hazmat/qemu.py
+++ b/src/fc/qemu/hazmat/qemu.py
@@ -571,14 +571,17 @@ class Qemu(object):
     def graceful_shutdown(self):
         if not self.qmp:
             return
-        self.qmp.command(
-            "send-key",
-            keys=[
-                {"type": "qcode", "data": "ctrl"},
-                {"type": "qcode", "data": "alt"},
-                {"type": "qcode", "data": "delete"},
-            ],
-        )
+        if self.cfg["environment_class"].lower() == "puppet":
+            self.qmp.command(
+                "send-key",
+                keys=[
+                    {"type": "qcode", "data": "ctrl"},
+                    {"type": "qcode", "data": "alt"},
+                    {"type": "qcode", "data": "delete"},
+                ],
+            )
+            return
+        self.qmp.command("system_powerdown")
 
     def destroy(self, kill_supervisor=False):
         # We use this destroy command in "fire-and-forget"-style because

--- a/src/fc/qemu/hazmat/qemu.py
+++ b/src/fc/qemu/hazmat/qemu.py
@@ -7,6 +7,7 @@ import socket
 import subprocess
 from codecs import encode
 from pathlib import Path
+from typing import List
 
 import psutil
 import yaml
@@ -18,7 +19,7 @@ from ..util import ControlledRuntimeException, log
 from .guestagent import ClientError, GuestAgent
 from .qmp import QEMUMonitorProtocol as Qmp
 from .qmp import QMPConnectError
-from typing import List
+
 # Freeze requests may take a _long_ _long_ time and the default
 # timeout of 3 seconds will cause everything to explode when
 # the guest takes too long. We've seen 16 seconds as a regular
@@ -434,13 +435,15 @@ class Qemu(object):
             if status["exited"] is True:
                 if "exitcode" in status:
                     if status["exitcode"] != 0:
-                        raise RuntimeError(f"Command failed with exitcode {status['exitcode']}")
+                        raise RuntimeError(
+                            f"Command failed with exitcode {status['exitcode']}"
+                        )
                     return
                 if "signal" in status:
-                    raise RuntimeError(f"Command was terminated with signal number {status['signal']}")
+                    raise RuntimeError(
+                        f"Command was terminated with signal number {status['signal']}"
+                    )
                 raise RuntimeError("Command was terminated abnormaly")
-
-
 
     def inmigrate(self):
         self._start([f"-incoming {self.migration_address}"])

--- a/src/fc/qemu/qemu.vm.cfg.in
+++ b/src/fc/qemu/qemu.vm.cfg.in
@@ -40,6 +40,15 @@
   aio = "threads"
   cache = "none"
 
+[drive]
+  index = "3"
+  media = "disk"
+  if = "virtio"
+  format = "rbd"
+  file = "rbd:{ceph.volumes[cidata].fullname}:id={{ceph_id}}"
+  aio = "threads"
+  cache = "none"
+
 [device]
   driver = "virtio-rng-pci"
 

--- a/src/fc/qemu/sysconfig.py
+++ b/src/fc/qemu/sysconfig.py
@@ -85,6 +85,7 @@ class SysConfig(object):
         self.ceph["CEPH_LOCK_HOST"] = self.cp.get("ceph", "lock_host")
         self.ceph["CREATE_VM"] = self.cp.get("ceph", "create-vm")
         self.ceph["MKFS_XFS"] = self.cp.get("ceph", "mkfs-xfs")
+        self.ceph["MKFS_VFAT"] = self.cp.get("ceph", "mkfs-vfat")
 
 
 sysconfig = SysConfig()

--- a/src/fc/qemu/util.py
+++ b/src/fc/qemu/util.py
@@ -176,3 +176,20 @@ def parse_export_format(data: str) -> Dict[str, str]:
         v = v.strip("'\"")
         result[k] = v
     return result
+
+
+def generate_cloudinit_ssh_keyfile(
+    users: List[Dict], resource_group: str
+) -> str:
+
+    authorized_ssh_keys = [
+        u["ssh_pubkey"]
+        for u in users
+        if set(u["permissions"][resource_group]) & set(["sudo-srv", "manager"])
+    ]
+    flattened_ssh_keys = sum(authorized_ssh_keys, [])
+    return (
+        "### managed by Flying Circus - do not edit! ###\n"
+        + "\n".join(flattened_ssh_keys)
+        + "\n"
+    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,7 +10,9 @@ import traceback
 from pathlib import Path
 from subprocess import check_call, getoutput
 from typing import List
+from unittest.mock import patch
 
+import mock
 import pytest
 import rados
 import rbd
@@ -724,6 +726,14 @@ def reset_structlog(setup_structlog):
     util.log_data = []
     util.test_log_start = time.time()
     util.test_log_options = {"show_methods": [], "show_events": []}
+
+
+@pytest.fixture()
+@patch('fc.qemu.directory.connect', autospec=True)
+def directory_mock(directory_connect_mock):
+    directory_mock = mock.Mock()
+    directory_connect_mock.side_effect = lambda _: directory_mock
+    yield directory_mock
 
 
 def get_log():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -396,6 +396,7 @@ def ceph_inst_cloudinit_enc(ceph_inst):
             "environment_class": "Ubuntu",
             "environment_class_type": "cloudinit",
             "resource_group": "test",
+            "disk": 10,
             "interfaces": {
                 "pub": {
                     "bridged": False,
@@ -420,6 +421,7 @@ def ceph_inst_cloudinit_enc(ceph_inst):
         },
     }
     yield ceph_inst
+    Path("/etc/qemu/users/test.json").unlink(missing_ok=True)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -731,7 +731,7 @@ def reset_structlog(setup_structlog):
 
 
 @pytest.fixture()
-@patch('fc.qemu.directory.connect', autospec=True)
+@patch("fc.qemu.directory.connect", autospec=True)
 def directory_mock(directory_connect_mock):
     directory_mock = mock.Mock()
     directory_connect_mock.side_effect = lambda _: directory_mock

--- a/tests/fixtures/simplevm.yaml
+++ b/tests/fixtures/simplevm.yaml
@@ -5,8 +5,12 @@ parameters:
   disk: 2
   id: 2345
   interfaces:
-    fe: {mac: aa-bb-cc-00-ee-ff}
-    srv: {mac: aa-bb-cc-dd-ee-ff}
+    fe:
+      mac: aa-bb-cc-00-ee-ff
+      networks:
+    srv:
+      mac: aa-bb-cc-dd-ee-ff
+      networks:
   kvm_host: host1
   memory: 256
   location: test
@@ -17,3 +21,5 @@ parameters:
   swap_size: 1073741824
   tmp_size: 5368709120
   environment: fc-21.05-dev
+  environment_class: NixOS
+  environment_class_type: nixos

--- a/tests/hazmat/test_ceph.py
+++ b/tests/hazmat/test_ceph.py
@@ -1,4 +1,4 @@
-from unittest.mock import patch, Mock
+from unittest.mock import Mock, patch
 
 import pytest
 import rbd
@@ -79,36 +79,36 @@ def test_cloud_init_seed(ceph_inst_cloudinit_enc):
 
     cidata_spec = ceph.specs["cidata"]
     cidata_spec.ensure_presence()
-    with patch("fc.qemu.directory.connect", autospec=True) as directory_connect_mock:
+    with patch(
+        "fc.qemu.directory.connect", autospec=True
+    ) as directory_connect_mock:
         directory_mock = Mock()
         directory_connect_mock.return_value = directory_mock
-        directory_mock.list_users.side_effect = lambda _rg: [{
-            "class": "human",
-            "email_addresses": [
-                "test@example.com"
-            ],
-            "gid": 100,
-            "home_directory": "/home/test",
-            "id": 1000,
-            "login_shell": "/bin/zsh",
-            "name": "Test Benutzer",
-            "password": "{CRYPT}$6$rounds=656000$foobar",
-            "permissions": {
-                "test": [
-                    "login",
-                    "sudo-srv"
-                ]
-            },
-            "ssh_pubkey": [
-                "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIO+C/OaWGUbNrf45RYxzgxzX2OZBPLH9VararPYDuorg"
-            ],
-            "uid": "test"
-        }]
+        directory_mock.list_users.side_effect = lambda _rg: [
+            {
+                "class": "human",
+                "email_addresses": ["test@example.com"],
+                "gid": 100,
+                "home_directory": "/home/test",
+                "id": 1000,
+                "login_shell": "/bin/zsh",
+                "name": "Test Benutzer",
+                "password": "{CRYPT}$6$rounds=656000$foobar",
+                "permissions": {"test": ["login", "sudo-srv"]},
+                "ssh_pubkey": [
+                    "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIO+C/OaWGUbNrf45RYxzgxzX2OZBPLH9VararPYDuorg"
+                ],
+                "uid": "test",
+            }
+        ]
         cidata_spec.start()
         directory_mock.list_users.assert_called_once_with("test")
     with cidata_spec.volume.mounted() as target:
         metadata_file = target / "meta-data"
-        assert metadata_file.read_text() == "instance-id: e0999536194a42170cde0d3698fb47ee\n"
+        assert (
+            metadata_file.read_text()
+            == "instance-id: e0999536194a42170cde0d3698fb47ee\n"
+        )
         userdata_file = target / "user-data"
         userdata_content = userdata_file.read_text()
         assert userdata_content.startswith("#cloud-config\n")
@@ -133,8 +133,8 @@ def test_cloud_init_seed(ceph_inst_cloudinit_enc):
 ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIO+C/OaWGUbNrf45RYxzgxzX2OZBPLH9VararPYDuorg
 """,
                     "path": "/root/.ssh/authorized_keys_fc",
-                    "permissions": "0600"
-                }
+                    "permissions": "0600",
+                },
             ],
             "runcmd": [
                 "systemctl enable --now qemu-guest-agent",

--- a/tests/hazmat/test_ceph.py
+++ b/tests/hazmat/test_ceph.py
@@ -1,11 +1,26 @@
 import pytest
 import rbd
+import yaml
 
 from tests.conftest import get_log
 
 
 @pytest.fixture
 def ceph_with_volumes(ceph_inst):
+    for vol in ceph_inst.specs.values():
+        vol.ensure_presence()
+    ceph_inst.lock()
+    yield ceph_inst
+    for volume in ceph_inst.opened_volumes:
+        volume.unlock(force=True)
+        volume.snapshots.purge()
+        volume.close()
+        rbd.RBD().remove(volume.ioctx, volume.name)
+
+
+@pytest.fixture
+def ceph_with_volumes_ci(ceph_inst_cloudinit_enc):
+    ceph_inst = ceph_inst_cloudinit_enc
     for vol in ceph_inst.specs.values():
         vol.ensure_presence()
     ceph_inst.lock()
@@ -52,10 +67,83 @@ def test_multiple_images_raises_error(ceph_inst):
 
 
 @pytest.mark.live()
+def test_cloud_init_seed(ceph_inst_cloudinit_enc):
+    ceph = ceph_inst_cloudinit_enc
+    rbd.RBD().create(
+        ceph.ioctxs["rbd.ssd"],
+        "simplevm.cidata",
+        ceph.cfg["cidata_size"],
+    )
+
+    cidata_spec = ceph.specs["cidata"]
+    cidata_spec.ensure_presence()
+    cidata_spec.start()
+    with cidata_spec.volume.mounted() as target:
+        metadata_file = target / "meta-data"
+        assert metadata_file.read_text() == "instance-id: simplevm\n"
+        userdata_file = target / "user-data"
+        userdata_content = userdata_file.read_text()
+        assert userdata_content.startswith("#cloud-config\n")
+        userdata_content_parsed = yaml.safe_load(userdata_content)
+        assert userdata_content_parsed == {
+            "allow_public_ssh_keys": True,
+            "ssh_pwauth": False,
+            "disable_root": False,
+            "package_update": True,
+            "packages": ["qemu-guest-agent"],
+            "hostname": "simplevm",
+            "users": [{"name": "root"}],
+            "write_files": [
+                {
+                    "content": "AuthorizedKeysFile .ssh/authorized_keys .ssh/authorized_keys_fc\n",
+                    "path": "/etc/ssh/sshd_config.d/10-cloud-init-fc.conf",
+                    "permissions": "0644",
+                }
+            ],
+            "runcmd": [
+                "systemctl enable --now qemu-guest-agent",
+                "systemctl restart ssh",
+            ],
+        }
+        network_config_file = target / "network-config"
+        network_config_content = network_config_file.read_text()
+        network_config_content_parsed = yaml.safe_load(network_config_content)
+        assert network_config_content_parsed == {
+            "config": [
+                {
+                    "accept-ra": False,
+                    "mac_address": "02:00:00:02:1d:e4",
+                    "name": "ethpub",
+                    "subnets": [
+                        {
+                            "address": "203.0.113.10/24",
+                            "dns_nameservers": ["9.9.9.9", "8.8.8.8"],
+                            "gateway": "293.0.113.1",
+                            "type": "static",
+                        },
+                        {
+                            "address": "2001:db8:500:2::5/64",
+                            "dns_nameservers": [
+                                "2620:fe::fe",
+                                "2001:4860:4860::8888",
+                            ],
+                            "gateway": "2001:db8:500:2::1",
+                            "type": "static6",
+                        },
+                    ],
+                    "type": "physical",
+                }
+            ],
+            "version": 1,
+        }
+
+
+@pytest.mark.live()
 def test_rbd_pool_migration(ceph_inst, patterns) -> None:
     ceph_inst.cfg["tmp_size"] = 500 * 1024 * 1024
     ceph_inst.cfg["swap_size"] = 50 * 1024 * 1024
     ceph_inst.cfg["root_size"] = 50 * 1024 * 1024
+    ceph_inst.cfg["cidata_size"] = 10 * 1024 * 1024
     rbd.RBD().create(
         ceph_inst.ioctxs["rbd.ssd"],
         "simplevm.root",
@@ -71,9 +159,15 @@ def test_rbd_pool_migration(ceph_inst, patterns) -> None:
         "simplevm.swap",
         ceph_inst.cfg["swap_size"],
     )
+    rbd.RBD().create(
+        ceph_inst.ioctxs["rbd.ssd"],
+        "simplevm.cidata",
+        ceph_inst.cfg["cidata_size"],
+    )
     assert ceph_inst.specs["root"].exists_in_pool() == "rbd.ssd"
     assert ceph_inst.specs["swap"].exists_in_pool() == "rbd.ssd"
     assert ceph_inst.specs["tmp"].exists_in_pool() == "rbd.ssd"
+    assert ceph_inst.specs["cidata"].exists_in_pool() == "rbd.ssd"
 
     ceph_inst.start()
     ceph_inst.status()
@@ -155,7 +249,34 @@ umount args="/mnt/rbd/rbd.hdd/simplevm.tmp" machine=simplevm subsystem=ceph volu
 umount machine=simplevm returncode=0 subsystem=ceph volume=rbd.hdd/simplevm.tmp
 rbd args=unmap "/dev/rbd/rbd.hdd/simplevm.tmp" machine=simplevm subsystem=ceph volume=rbd.hdd/simplevm.tmp
 rbd machine=simplevm returncode=0 subsystem=ceph volume=rbd.hdd/simplevm.tmp
-
+pre-start machine=simplevm subsystem=ceph volume_spec=cidata
+delete-outdated-cloud-init image=simplevm.cidata machine=simplevm pool=rbd.ssd subsystem=ceph volume=simplevm.cidata
+ensure-presence machine=simplevm subsystem=ceph volume_spec=cidata
+lock machine=simplevm subsystem=ceph volume=rbd.hdd/simplevm.cidata
+ensure-size machine=simplevm subsystem=ceph volume_spec=cidata
+start machine=simplevm subsystem=ceph volume_spec=cidata
+start-cloud-init machine=simplevm subsystem=ceph volume=rbd.hdd/simplevm.cidata
+rbd args=map "rbd.hdd/simplevm.cidata" machine=simplevm subsystem=ceph volume=rbd.hdd/simplevm.cidata
+rbd>    /dev/rbd0
+rbd machine=simplevm returncode=0 subsystem=ceph volume=rbd.hdd/simplevm.cidata
+create-fs machine=simplevm subsystem=ceph volume=rbd.hdd/simplevm.cidata
+sgdisk args=-o "/dev/rbd/rbd.hdd/simplevm.cidata" machine=simplevm subsystem=ceph volume=rbd.hdd/simplevm.cidata
+sgdisk> Creating new GPT entries in memory.
+sgdisk> The operation has completed successfully.
+sgdisk machine=simplevm returncode=0 subsystem=ceph volume=rbd.hdd/simplevm.cidata
+sgdisk args=-n 1:: -c "1:cidata" -t 1:8300 "/dev/rbd/rbd.hdd/simplevm.cidata" machine=simplevm subsystem=ceph volume=rbd.hdd/simplevm.cidata
+sgdisk> The operation has completed successfully.
+sgdisk machine=simplevm returncode=0 subsystem=ceph volume=rbd.hdd/simplevm.cidata
+partprobe args=/dev/rbd/rbd.hdd/simplevm.cidata machine=simplevm subsystem=ceph volume=rbd.hdd/simplevm.cidata
+partprobe machine=simplevm returncode=0 subsystem=ceph volume=rbd.hdd/simplevm.cidata
+waiting interval=0 machine=simplevm remaining=4 subsystem=ceph volume=rbd.hdd/simplevm.cidata
+mkfs.vfat args=-n "cidata" /dev/rbd/rbd.hdd/simplevm.cidata-part1 machine=simplevm subsystem=ceph volume=rbd.hdd/simplevm.cidata
+mkfs.vfat>      mkfs.fat: Warning: lowercase labels might not work properly on some systems
+mkfs.vfat>      mkfs.fat 4.2 (2021-01-31)
+mkfs.vfat machine=simplevm returncode=0 subsystem=ceph volume=rbd.hdd/simplevm.cidata
+seed machine=simplevm subsystem=ceph volume=rbd.hdd/simplevm.cidata
+rbd args=unmap "/dev/rbd/rbd.hdd/simplevm.cidata" machine=simplevm subsystem=ceph volume=rbd.hdd/simplevm.cidata
+rbd machine=simplevm returncode=0 subsystem=ceph volume=rbd.hdd/simplevm.cidata
 rbd-status locker=None machine=simplevm subsystem=ceph volume=rbd.hdd/simplevm.root
 rbd args=status --format json rbd.hdd/simplevm.root machine=simplevm subsystem=ceph volume=rbd.hdd/simplevm.root
 rbd>    {"watchers":[{"address":"...:0/...","client":...,"cookie":...}],"migration":{"source_pool_name":"rbd.ssd","source_pool_namespace":"","source_image_name":"simplevm.root","source_image_id":"...","dest_pool_name":"rbd.hdd","dest_pool_namespace":"","dest_image_name":"simplevm.root","dest_image_id":"...","state":"prepared","state_description":""}}
@@ -163,6 +284,7 @@ rbd machine=simplevm returncode=0 subsystem=ceph volume=rbd.hdd/simplevm.root
 root-migration-status machine=simplevm pool_from=rbd.ssd pool_to=rbd.hdd progress= status=prepared subsystem=ceph volume=rbd.hdd/simplevm.root
 rbd-status locker=('client...', '...') machine=simplevm subsystem=ceph volume=rbd.hdd/simplevm.swap
 rbd-status locker=('client...', '...') machine=simplevm subsystem=ceph volume=rbd.hdd/simplevm.tmp
+rbd-status locker=('client...', '...') machine=simplevm subsystem=ceph volume=rbd.hdd/simplevm.cidata
 """
     )
 
@@ -171,6 +293,7 @@ rbd-status locker=('client...', '...') machine=simplevm subsystem=ceph volume=rb
     assert ceph_inst.specs["root"].exists_in_pool() == "rbd.hdd"
     assert ceph_inst.specs["swap"].exists_in_pool() == "rbd.hdd"
     assert ceph_inst.specs["tmp"].exists_in_pool() == "rbd.hdd"
+    assert ceph_inst.specs["cidata"].exists_in_pool() == "rbd.hdd"
 
     ceph_inst.ensure()
     ceph_inst.status()
@@ -196,6 +319,7 @@ root-migration-status machine=simplevm pool_from=rbd.ssd pool_to=rbd.hdd progres
 
 rbd-status locker=('client...', '...') machine=simplevm subsystem=ceph volume=rbd.hdd/simplevm.swap
 rbd-status locker=('client...', '...') machine=simplevm subsystem=ceph volume=rbd.hdd/simplevm.tmp
+rbd-status locker=('client...', '...') machine=simplevm subsystem=ceph volume=rbd.hdd/simplevm.cidata
 """
     )
 
@@ -226,6 +350,7 @@ rbd machine=simplevm returncode=0 subsystem=ceph volume=rbd.hdd/simplevm.root
 
 rbd-status locker=('client...', '...') machine=simplevm subsystem=ceph volume=rbd.hdd/simplevm.swap
 rbd-status locker=('client...', '...') machine=simplevm subsystem=ceph volume=rbd.hdd/simplevm.tmp
+rbd-status locker=('client...', '...') machine=simplevm subsystem=ceph volume=rbd.hdd/simplevm.cidata
 """
     )
 

--- a/tests/test_binenv.py
+++ b/tests/test_binenv.py
@@ -7,6 +7,7 @@ import tests.conftest
 REQUIRED_BINARIES = set(
     [  # production
         "blkid",
+        "mkfs.vfat",
         "mkfs.xfs",
         "mkswap",
         "mount",


### PR DESCRIPTION
* Add cloud-init disk with config files
* update root ssh keys via qemu agent in ensure for ubuntu VMs

PL-133325 and PL-133372

## Release process

- [x] Created changelog entry using `./changelog.sh`

## PR release workflow (internal)

- [x] PR has internal ticket
- [x] internal issue ID (PL-…) part of branch name
- [x] internal issue ID mentioned in PR description text
- [x] ticket is on Platform agile board
- [ ] ticket state set to *Pull request ready*
- [ ] if ticket is more urgent than within the next few days, directly contact a member of the Platform team

## Design notes

- [x] Provide a feature toggle if the change might need to be adjusted/reverted quickly depending on context. Consider whether the default should be `on` or `off`. Example: rate limiting.
- [x] ~~All customer-facing features and (NixOS) options need to be discoverable from documentation. Add or update relevant documentation such that hosted and guided customers can understand it as well.~~ (will be done later, is noted)

## Security implications

- [ ] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)

- [ ] Security requirements tested? (EVIDENCE)

* automated testing (tbd), manual testing, and code review

