### PR TITLE
WIP: fix xfs UUID regeneration

### DIFF
--- a/src/fc/qemu/hazmat/ceph.py
+++ b/src/fc/qemu/hazmat/ceph.py
@@ -263,7 +263,7 @@ class RootSpec(VolumeSpecification):
                 # Mount once to ensure a clean log.
                 pass
             self.log.info("regenerate-xfs-uuid", device=partition)
-            self.cmd(f"xfs_admin -U generate {partition}")
+            self.cmd(f"xfs_db -x -c 'uuid generate' {partition}")
 
 
 class TmpSpec(VolumeSpecification):

--- a/tests/test_binenv.py
+++ b/tests/test_binenv.py
@@ -20,6 +20,7 @@ REQUIRED_BINARIES = set(
         "systemctl",
         "umount",
         "xfs_admin",
+        "xfs_db",
         "parted",
     ]
 )

--- a/tests/test_vm.py
+++ b/tests/test_vm.py
@@ -221,11 +221,11 @@ mount machine=simplevm returncode=0 subsystem=ceph volume=rbd.ssd/simplevm.root
 umount args="/mnt/rbd/rbd.ssd/simplevm.root" machine=simplevm subsystem=ceph volume=rbd.ssd/simplevm.root
 umount machine=simplevm returncode=0 subsystem=ceph volume=rbd.ssd/simplevm.root
 regenerate-xfs-uuid device=/dev/rbd/rbd.ssd/simplevm.root-part1 machine=simplevm subsystem=ceph volume=rbd.ssd/simplevm.root
-xfs_admin args=-U generate /dev/rbd/rbd.ssd/simplevm.root-part1 machine=simplevm subsystem=ceph volume=rbd.ssd/simplevm.root
-xfs_admin> Clearing log and setting UUID
-xfs_admin> writing all SBs
-xfs_admin> new UUID = ...-...-...-...-...
-xfs_admin machine=simplevm returncode=0 subsystem=ceph volume=rbd.ssd/simplevm.root
+xfs_db args=-x -c 'uuid generate' /dev/rbd/rbd.ssd/simplevm.root-part1 machine=simplevm subsystem=ceph volume=rbd.ssd/simplevm.root
+xfs_db> Clearing log and setting UUID
+xfs_db> writing all SBs
+xfs_db> new UUID = ...-...-...-...-...
+xfs_db machine=simplevm returncode=0 subsystem=ceph volume=rbd.ssd/simplevm.root
 rbd args=unmap "/dev/rbd/rbd.ssd/simplevm.root" machine=simplevm subsystem=ceph volume=rbd.ssd/simplevm.root
 rbd machine=simplevm returncode=0 subsystem=ceph volume=rbd.ssd/simplevm.root
 """


### PR DESCRIPTION

Modifying the XFS uuid of the VM image's root partition failed, because it was supposedly already mounted. In fact it was not, but we are hitting an edge case of the interplay of xfs_admin, findmnt, filesystem labels, and udev, see PL-133416 for details:

- In fc-nixos we configure hosts to locate filesystems at boot times using filesystem labels. In particular, for the mount point / we uses the device with the label "root", and hence configure a source device of `/dev/disk/by-label/root`. This refers to the root filesystem device using the symlink created by udev when the partition is mapped at boot time.
- When we later attach an nbd image in order to perform operations before booting the guest, the kernel automatically maps the partition table inside the image. It discovers that the first partition has an XFS filesystem, which also has the label "root". When udev processes the device being mapped, **it overwrites the existing symlink in `/dev/disk/by-label`** to point to the device node for the partition on the nbd image.
- `xfs_admin` is a shell script, which wraps lower level tools like `xfs_db` with a more convenient interface.
  - The version in 21.05 simply processes the script arguments and then blindly executes `xfs_db`.
  - However, the version in 24.11 has gained the ability to modify some filesystem attributes at runtime using a different command, `xfs_io`. In order to determine which command to use, the script therefore invokes `findmnt` from util-linux to resolve the named block device to a mount point, if one exists.
  - `findmnt` resolves the mount points using procfs and sysfs. If any mountpoints use symlinks under `/dev/disk` they are also evaluated, to detect cases where the queried partition was mounted through one of those symlinks.
- When reading the filesystem UUID for the nbd partition, `findmnt` misidentifies the nbd partition as the root partion (due to `/dev/disk/by-label/root` being rewritten), and then runs `xfs_io` to print the UUID of the currently mounted root filesystem.
- When attempting to change the filesystem UUID for the nbd partition, the same misidentification causes `xfs_admin` to assume that the partition is already mounted as the root filesystem, and refuses to change the UUID.
- From reading through `xfs_admin`, if this collision did not occur and it managed to correctly identify that the nbd partition is not mounted, then it should run the "uuid" command from `xfs_db` to change the UUID of the XFS filesystem on the nbd partition.

TL;DR: replace `xfs_admin -U insert-uuid-here /path/to/device` with `xfs_db -x -c 'uuid insert-uuid-here' /path/to/device`.

PL-133416