### PR TITLE
scrubbing/ensure: do not open ceph connections for offline vms

### DIFF
--- a/src/fc/qemu/hazmat/libceph.py
+++ b/src/fc/qemu/hazmat/libceph.py
@@ -37,16 +37,10 @@ class Rados:
         self.log = log.bind(subsystem="libceph")
         self._ioctx = {}
 
-    def connect(self):
-        pass
-
     def open_ioctx(self, pool):
         if pool not in self._ioctx:
             self._ioctx[pool] = Ioctx(self, pool)
         return self._ioctx[pool]
-
-    def shutdown(self):
-        pass
 
     def _ceph(self, *args, use_json=True):
         shargs = shlex.join(args)

--- a/src/fc/qemu/main.py
+++ b/src/fc/qemu/main.py
@@ -68,6 +68,7 @@ def main():
 
     a = argparse.ArgumentParser(description="Qemu VM agent")
     a.set_defaults(func="print_usage")
+    a.set_defaults(ceph_attach_on_enter=True)
 
     a.add_argument(
         "--verbose",
@@ -111,6 +112,7 @@ def main():
     p = sub.add_parser("ensure", help="Ensure proper status of the VM.")
     p.add_argument("vm", metavar="VM", help="name of the VM")
     p.set_defaults(func="ensure")
+    p.set_defaults(ceph_attach_on_enter=False)
 
     p = sub.add_parser("start", help="Start a VM.")
     p.add_argument("vm", metavar="VM", help="name of the VM")
@@ -200,6 +202,7 @@ def main():
         del kwargs["vm"]
     del kwargs["daemonize"]
     del kwargs["verbose"]
+    del kwargs["ceph_attach_on_enter"]
 
     if args.daemonize:
         # Needed to help spawn subprocesses from consul without blocking.
@@ -229,6 +232,7 @@ def main():
                 # a bit more explicit.
                 vm = os.path.basename(vm).split(".")[0]
             agent = Agent(vm)
+            agent.ceph_attach_on_enter = args.ceph_attach_on_enter
             with agent:
                 sys.exit(getattr(agent, func)(**kwargs) or 0)
     except ControlledRuntimeException:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,7 +20,7 @@ import fc.qemu.agent
 import fc.qemu.hazmat.qemu
 import fc.qemu.logging
 from fc.qemu.agent import Agent
-from fc.qemu.hazmat import libceph, volume
+from fc.qemu.hazmat import libceph
 from fc.qemu.hazmat.ceph import Ceph, RootSpec, VolumeSpecification
 from fc.qemu.util import GiB
 
@@ -35,20 +35,11 @@ class RadosMock(object):
         self.conffile = conffile
         self.name = name
         self._ioctx = {}
-        self.__connected__ = False
-
-    def connect(self):
-        assert not self.__connected__
-        self.__connected__ = True
 
     def open_ioctx(self, pool):
         if pool not in self._ioctx:
             self._ioctx[pool] = IoctxMock(pool, self.tmp_path)
         return self._ioctx[pool]
-
-    def shutdown(self):
-        assert self.__connected__
-        self.__connected__ = False
 
     def list_pools(self):
         return ["rbd", "data", "rbd.ssd", "rbd.hdd", "rbd.rgw.foo"]

--- a/tests/hazmat/test_ceph.py
+++ b/tests/hazmat/test_ceph.py
@@ -302,8 +302,6 @@ mkfs.xfs>       mkfs.xfs: small data volume, ignoring data volume stripe unit 12
     )
     first_start.in_order(
         """
-connect-rados machine=simplevm subsystem=ceph
-
 pre-start machine=simplevm subsystem=ceph volume_spec=root
 ensure-presence machine=simplevm subsystem=ceph volume_spec=root
 lock machine=simplevm subsystem=ceph volume=rbd.ssd/simplevm.root

--- a/tests/test_consul.py
+++ b/tests/test_consul.py
@@ -315,7 +315,6 @@ def test_snapshot_offline_vm(vm):
         """\
 start-consul-events count=1
 handle-key key=snapshot/7468743
-connect-rados machine=simplevm subsystem=ceph
 snapshot machine=simplevm snapshot=backy-1234
 acquire-lock machine=simplevm target=...run/qemu.simplevm.lock
 acquire-lock count=1 machine=simplevm result=locked target=...run/qemu.simplevm.lock


### PR DESCRIPTION
The majority of VMs that we call `ensure` for (during scrubbing) will be intended to be (locally) offline and are offline. Optimize the performance for this by avoiding calls to Ceph.

Also, a few cleanups.