### PR TITLE
cloud-init: Add ipv6 nameserver, use hostname as instance-id, upgrade packages on start (and fix cloud-init once only scripts)

### DIFF
--- a/src/fc/qemu/hazmat/ceph.py
+++ b/src/fc/qemu/hazmat/ceph.py
@@ -474,6 +474,11 @@ class CloudInitSpec(VolumeSpecification):
                         "package_upgrade": True,
                         "packages": ["qemu-guest-agent"],
                         "hostname": enc["name"],
+                        "updates": {
+                            "network": {
+                                "when": ["boot-new-instance", "boot"],
+                            },
+                        },
                         # don't create ubuntu user, but only root
                         "users": [{"name": "root"}],
                         "write_files": managed_files,

--- a/src/fc/qemu/hazmat/ceph.py
+++ b/src/fc/qemu/hazmat/ceph.py
@@ -456,17 +456,11 @@ class CloudInitSpec(VolumeSpecification):
             }
         )
 
-        enc_to_hash = enc.copy()
-        enc_to_hash.pop("last_maintenance_end", None)
-        enc_to_hash.pop("consul-generation", None)
-        enc_to_hash["parameters"].pop("kvm_host", None)
-        enc_hash = hashlib.md5(json.dumps(enc_to_hash, sort_keys=True).encode())
-        instance_id = enc_hash.hexdigest()
         with self.volume.mounted() as target:
             metadata = target / "meta-data"
             metadata.touch()
             with metadata.open("w") as f:
-                yaml.safe_dump({"instance-id": instance_id}, f)
+                yaml.safe_dump({"instance-id": enc["name"]}, f)
             userdata = target / "user-data"
             userdata.touch()
             with userdata.open("w") as f:
@@ -485,8 +479,6 @@ class CloudInitSpec(VolumeSpecification):
                         "runcmd": [
                             "systemctl enable --now qemu-guest-agent",
                             "systemctl restart ssh",
-                            "sed -ie 's/- ssh/- [ssh, once]/' /etc/cloud/cloud.cfg",
-                            "sed -ie 's/- set_passwords/- [set_passwords, once]/' /etc/cloud/cloud.cfg",
                         ],
                     },
                     f,

--- a/src/fc/qemu/hazmat/ceph.py
+++ b/src/fc/qemu/hazmat/ceph.py
@@ -31,7 +31,7 @@ from .volume import Volume
 # VMs match each other.
 ROUTED_VIRTUAL_GATEWAY_V4 = "169.254.83.168"
 ROUTED_VIRTUAL_GATEWAY_V6 = "fe80::1"
-ROUTED_VIRTUAL_NAMESERVER = "169.254.83.168"
+ROUTED_VIRTUAL_NAMESERVER_V4 = "169.254.83.168"
 
 
 def valid_rbd_pool_name(name):
@@ -518,10 +518,14 @@ class CloudInitSpec(VolumeSpecification):
                             ]
                         case (True, 4):
                             gateway = ROUTED_VIRTUAL_GATEWAY_V4
-                            nameservers = [ROUTED_VIRTUAL_NAMESERVER]
+                            nameservers = [ROUTED_VIRTUAL_NAMESERVER_V4]
                         case (True, 6):
                             gateway = ROUTED_VIRTUAL_GATEWAY_V6
-                            nameservers = []
+                            nameservers = (
+                                [str(ip_network[1])]
+                                if ip_network.num_addresses >= 4
+                                else []
+                            )
                         case _:
                             continue
                     for address in netconfig:

--- a/src/fc/qemu/hazmat/ceph.py
+++ b/src/fc/qemu/hazmat/ceph.py
@@ -471,6 +471,7 @@ class CloudInitSpec(VolumeSpecification):
                         "ssh_pwauth": False,
                         "disable_root": False,
                         "package_update": True,
+                        "package_upgrade": True,
                         "packages": ["qemu-guest-agent"],
                         "hostname": enc["name"],
                         # don't create ubuntu user, but only root

--- a/tests/hazmat/test_ceph.py
+++ b/tests/hazmat/test_ceph.py
@@ -130,6 +130,14 @@ def test_cloud_init_seed_simple(ceph_inst_cloudinit_enc):
             "package_upgrade": True,
             "packages": ["qemu-guest-agent"],
             "hostname": "simplevm",
+            "updates": {
+                "network": {
+                    "when": [
+                        "boot-new-instance",
+                        "boot",
+                    ],
+                },
+            },
             "users": [{"name": "root"}],
             "write_files": [
                 {

--- a/tests/hazmat/test_ceph.py
+++ b/tests/hazmat/test_ceph.py
@@ -127,6 +127,7 @@ def test_cloud_init_seed_simple(ceph_inst_cloudinit_enc):
             "ssh_pwauth": False,
             "disable_root": False,
             "package_update": True,
+            "package_upgrade": True,
             "packages": ["qemu-guest-agent"],
             "hostname": "simplevm",
             "users": [{"name": "root"}],

--- a/tests/hazmat/test_ceph.py
+++ b/tests/hazmat/test_ceph.py
@@ -117,10 +117,7 @@ def test_cloud_init_seed_simple(ceph_inst_cloudinit_enc):
         directory_mock.list_users.assert_called_once_with("test")
     with cidata_spec.volume.mounted() as target:
         metadata_file = target / "meta-data"
-        assert (
-            metadata_file.read_text()
-            == "instance-id: e0999536194a42170cde0d3698fb47ee\n"
-        )
+        assert metadata_file.read_text() == "instance-id: simplevm\n"
         userdata_file = target / "user-data"
         userdata_content = userdata_file.read_text()
         assert userdata_content.startswith("#cloud-config\n")
@@ -151,8 +148,6 @@ ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIO+C/OaWGUbNrf45RYxzgxzX2OZBPLH9VararPYDuorg
             "runcmd": [
                 "systemctl enable --now qemu-guest-agent",
                 "systemctl restart ssh",
-                "sed -ie 's/- ssh/- [ssh, once]/' /etc/cloud/cloud.cfg",
-                "sed -ie 's/- set_passwords/- [set_passwords, once]/' /etc/cloud/cloud.cfg",
             ],
         }
         network_config_file = target / "network-config"
@@ -186,31 +181,6 @@ ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIO+C/OaWGUbNrf45RYxzgxzX2OZBPLH9VararPYDuorg
             ],
             "version": 1,
         }
-
-
-def test_cloud_init_seed_instance_id_hashing(ceph_inst_cloudinit_enc):
-    ceph = ceph_inst_cloudinit_enc
-    libceph.RBD().create(
-        ceph.ioctxs["rbd.ssd"],
-        "simplevm.cidata",
-        ceph.cfg["cidata_size"],
-    )
-
-    cidata_spec = ceph.specs["cidata"]
-    cidata_spec.ensure_presence()
-    cidata_spec.start()
-    with cidata_spec.volume.mounted() as target:
-        metadata_file = target / "meta-data"
-        metadata_config = yaml.safe_load(metadata_file.read_text())
-        previous_instance_id = metadata_config["instance-id"]
-
-    ceph_inst_cloudinit_enc.enc["disk"] = 20
-    cidata_spec = ceph.specs["cidata"]
-    cidata_spec.start()
-    with cidata_spec.volume.mounted() as target:
-        metadata_file = target / "meta-data"
-        metadata_config = yaml.safe_load(metadata_file.read_text())
-        assert metadata_config["instance-id"] != previous_instance_id
 
 
 def test_cloud_init_seed_routed_pub(ceph_inst_cloudinit_enc):

--- a/tests/hazmat/test_ceph.py
+++ b/tests/hazmat/test_ceph.py
@@ -214,7 +214,7 @@ def test_cloud_init_seed_routed_pub(ceph_inst_cloudinit_enc):
                         },
                         {
                             "address": "2001:db8:500:2::5/128",
-                            "dns_nameservers": [],
+                            "dns_nameservers": ["2001:db8:500:2::1"],
                             "gateway": "fe80::1",
                             "type": "static6",
                         },


### PR DESCRIPTION
Tested on kyle09. See commits for detailed reasoning

PL-133325