### PR TITLE
outmigrate: improve rescue resilience to name resolution errors

### DIFF
--- a/src/fc/qemu/hazmat/ceph.py
+++ b/src/fc/qemu/hazmat/ceph.py
@@ -15,6 +15,9 @@ import yaml
 
 import fc.qemu.directory
 import fc.qemu.hazmat.libceph as libceph
+from fc.qemu.hazmat.libceph import (
+    NameResolutionError as NameResolutionError,  # re-export
+)
 from fc.qemu.util import (
     conditional_update,
     generate_cloudinit_ssh_keyfile,
@@ -381,8 +384,7 @@ class TmpSpec(VolumeSpecification):
         assert device, f"volume must be mapped first: {device}"
         self.cmd(f'sgdisk -o "{device}"')
         self.cmd(
-            f'sgdisk -a 8192 -n 1:8192:0 -c "1:{self.suffix}" '
-            f'-t 1:8300 "{device}"'
+            f'sgdisk -a 8192 -n 1:8192:0 -c "1:{self.suffix}" -t 1:8300 "{device}"'
         )
         # XXX remove when all machines can read from cidata
         self.volume.wait_for_part1dev()

--- a/tests/test_outgoing.py
+++ b/tests/test_outgoing.py
@@ -1,3 +1,5 @@
+import errno
+
 import mock
 import pytest
 
@@ -17,9 +19,84 @@ def test_prefer_remote_rescue(outgoing):
     assert outgoing.agent.qemu.destroy.called is True
 
 
-def test_request_remote_destroy_if_remote_rescue_fails(outgoing):
+@pytest.fixture
+def outgoing_broken_remote(outgoing):
+    """outgoing mock where the remote rescuee throws an exception"""
     outgoing.target.rescue.side_effect = RuntimeError("boom")
+    return outgoing
+
+
+def test_request_remote_destroy_if_remote_rescue_fails(outgoing_broken_remote):
+    outgoing = outgoing_broken_remote
     outgoing.rescue()
     assert outgoing.target.destroy.called is True
     assert outgoing.agent.qemu.destroy.called is False
     assert outgoing.agent.ceph.lock.called is True
+
+
+def test_rescue_continue_on_name_resolution_error(
+    outgoing_broken_remote, caplog
+):
+    """rescue shall continue to run the VM locally despite ceph lock name resolution
+    errors, if our heuristics state that the images are still locked by the local host
+    """
+    from fc.qemu.hazmat.ceph import NameResolutionError
+
+    o = outgoing_broken_remote
+    o.agent.ceph.lock.side_effect = NameResolutionError(
+        errno.ECONNABORTED, "Test name resolution error"
+    )
+    o.rescue()
+    assert o.agent.qemu.destroy.called is False
+
+
+def test_rescue_destroy_on_other_errors(outgoing_broken_remote, caplog):
+    """rescue shall still abort the locally running VM on unknown other errors
+    than the unlock name resolution error.
+    """
+    from subprocess import CalledProcessError
+
+    o = outgoing_broken_remote
+    o.agent.ceph.lock.side_effect = CalledProcessError(
+        23, "rbd lock rbd.ssd/test.root"
+    )
+    o.rescue()
+    assert o.agent.qemu.destroy.called is True
+
+
+def test_rescue_destroy_on_name_resolution_error_when_locks_transferred(
+    outgoing_broken_remote, caplog
+):
+    """rescue shall destroy the local running VM in the face of ceph lock name resolution
+    errors, if the locks *might* have been transfered.
+    """
+    from fc.qemu.hazmat.ceph import NameResolutionError
+
+    o = outgoing_broken_remote
+    o.transfer_ceph_locks()
+    o.agent.ceph.lock.side_effect = NameResolutionError(
+        errno.ECONNABORTED, "Test name resolution error"
+    )
+    o.rescue()
+    assert o.agent.qemu.destroy.called is True
+
+
+def test_rescue_destroy_on_name_resolution_error_when_locks_transferred_with_exception(
+    outgoing_broken_remote, caplog
+):
+    """
+    Same as test_rescue_destroy_on_name_resolution_error_when_locks_transferred,
+    but in the face of an exception when transferring the ceph lock.
+    """
+    from fc.qemu.hazmat.ceph import NameResolutionError
+
+    o = outgoing_broken_remote
+    name_err = NameResolutionError(
+        errno.ECONNABORTED, "Test name resolution error"
+    )
+    o.agent.ceph.unlock.side_effect = name_err
+    with pytest.raises(NameResolutionError):
+        o.transfer_ceph_locks()
+    o.agent.ceph.lock.side_effect = name_err
+    o.rescue()
+    assert o.agent.qemu.destroy.called is True


### PR DESCRIPTION
We have seen twice (PL-133752, PL-133891) that name resolution errors in our internal network cause VM migrations during that time to not only fail, but the supposed `rescue` job then destroyed the local running VM which would otherwise have continued to run well.

After tracking this down to an exception in the `ceph.lock` call during rescue, I came to the conclusion that our libceph/librbd/librados reimplementation via the ceph CLI is now much more susceptible to name resolution errors, as each CLI command call tries to resolve mon hostnames again and again. The real ceph lib bindings might have done some caching or so, I did not check.

As I did not see a simple and general approach to countering that regression, I have decided to enrich the exceptions thrown by libceph with the information of this special type of error – a NameResolutionError exception. Consuming code can then use this information to implement special case handling where it matters and is mandated – like in the Outgoing.rescue part. When we are currently running the "original" vm and an outgoing migration fails before we even attempted to transfer the ceph lock, we can of course still check the volume lock status at rescue time – but if that just fails due to a mere name resolution error, keeping the VM running is the more appropriate reaction than destroying it.

I added some basic unit tests for crucial cases, but did not run the whole test suite yet due to devhost oddities.
We might also want to cover this special case in a live integration test.

Remaining tasks:
- can the ceph lock migration be shifted to *after* the actual migration, to widen the window where we can rescue with a clear conscience to "as long as the migration progress is <100%"?
- check test suite
- extend integration tests