### PR TITLE
batou: bump to fc-nixos-25.11

### DIFF
--- a/batou/components/nixos/component.py
+++ b/batou/components/nixos/component.py
@@ -1,5 +1,6 @@
 import json
 from pathlib import Path
+from typing import Any, Callable
 
 from batou.component import Attribute, Component
 from batou.lib.file import File
@@ -25,6 +26,7 @@ def update_merge(d1, d2):
 class JSONUpdate(Component):
     namevar = "path"
     updates: list[dict] = Attribute()
+    post_process: list[Callable[[dict[Any, Any]], None]] = Attribute()
 
     def configure(self):
         self._path = self.path
@@ -35,6 +37,8 @@ class JSONUpdate(Component):
         self.new_data = {}
         for update in self.updates:
             self.new_data = update_merge(self.new_data, update)
+        for processor in self.post_process:
+            processor(self.new_data)
 
         p = Path(self.path)
         assert p.exists()
@@ -99,11 +103,16 @@ class NixOS(Component):
 
         # Our dependencies are reversed: we first need to configure the
         # NixOS environment and then the individual parts can do their work
+        #
+        def filter_roles(enc: dict[Any, Any]):
+            enc["roles"] = list(sorted(set(enc["roles"])))
+
         self += (
             enc := JSONUpdate(
                 "/etc/nixos/enc.json",
                 updates=[enc]
                 + list(self.require("enc", host=self.host, reverse=True)),
+                post_process=[filter_roles],
             )
         )
 
@@ -129,4 +138,4 @@ class NixOS(Component):
         if Path("/home/developer/fc-nixos").exists():
             with self.chdir("/home/developer/fc-nixos"):
                 self.cmd("./dev-setup")
-        self.cmd("fc-manage --build")
+        self.cmd("fc-manage switch")

--- a/batou/components/tests/tests.nix
+++ b/batou/components/tests/tests.nix
@@ -65,7 +65,7 @@ in
     serviceConfig = {
       Type = "simple";
       Restart = "always";
-      ExecStart = "${pkgs.python3Full}/bin/python ${./fakedirectory.py}";
+      ExecStart = "${pkgs.python3}/bin/python ${./fakedirectory.py}";
     };
   };
 

--- a/batou/environments/dev/environment.cfg
+++ b/batou/environments/dev/environment.cfg
@@ -9,6 +9,9 @@ host = largo01.fcdev.fcio.net
 release = https://my.flyingcircus.io/releases/metadata/fc-25.11-dev
 memory = 8096
 cores = 2
+# Use this if you want to work with a developer checkout
+# of the fc-nixos platform. Also see provision.sh
+#update_channel = False
 
 [host:host1]
 provision-dynamic-hostname = True

--- a/batou/environments/dev/environment.cfg
+++ b/batou/environments/dev/environment.cfg
@@ -6,7 +6,7 @@ update_method = rsync
 [provisioner:default]
 method = fc-nixos-dev-vm
 host = largo01.fcdev.fcio.net
-release = https://my.flyingcircus.io/releases/metadata/fc-24.11-dev
+release = https://my.flyingcircus.io/releases/metadata/fc-25.11-dev
 memory = 8096
 cores = 2
 

--- a/batou/environments/dev/provision.sh
+++ b/batou/environments/dev/provision.sh
@@ -1,8 +1,10 @@
 COPY ../../../../fc.qemu /home/developer/
 RUN chown developer: -R /home/developer/fc.qemu
 # Use this if you want to work with a developer checkout
-# of the fc-nixos platform.
-#COPY ../../../../fc-nixos /home/developer/
+# of the fc-nixos platform. Also see environment.cfg
+#COPY ~/PATH/TO/LOCAL/fc-nixos/ /home/developer/fc-nixos
 #RUN chown developer: -R /home/developer/fc-nixos
 #RUN rm -rf /home/developer/fc-nixos/channels
+## un-confuse nix flake references
+#RUN rm -rf /home/developer/fc-nixos/.git
 #RUN /home/developer/fc-nixos/dev-setup

--- a/batou/requirements.lock
+++ b/batou/requirements.lock
@@ -1,19 +1,19 @@
-# appenv-requirements-hash: 0f98d78663247bfc02f531ad77e13cfb0763670829589f50c845e929fcb70c8b
+# appenv-requirements-hash: 7dbd9dbba98d08cf4804d89ef5db2a0f1d2e1ce7f61be6cf166c103e5fe1d173
 ConfigUpdater==3.2
 Jinja2==3.1.6
-MarkupSafe==3.0.2
-PyYAML==6.0.2
-batou @ https://github.com/flyingcircusio/batou/archive/f99d8dd9604edc336f7ae4424f751373c2db2ce9.zip#sha256=c5c1855c9ea96d82e1bb0275152077cfe2d47be32d159205de768bb4e007827b
+MarkupSafe==3.0.3
+PyYAML==6.0.3
+batou @ https://github.com/flyingcircusio/batou/archive/eed3dc5274457cc2828cb5e6334f5c31ae1e719a.zip#sha256=29c18f5b963064ee8e2f0a69fbc4ff750b29d80882f9277fc713305a0d66d3ea
 
-certifi==2025.1.31
-charset-normalizer==3.4.1
-execnet==2.1.1
-idna==3.10
-importlib_metadata==8.6.1
+certifi==2026.2.25
+charset-normalizer==3.4.4
+execnet==2.1.2
+idna==3.11
+importlib_metadata==8.7.1
 importlib_resources==6.5.2
 py==1.11.0
 remote-pdb==2.1.0
-requests==2.32.3
-setuptools==76.1.0
-urllib3==2.3.0
-zipp==3.21.0
+requests==2.32.5
+setuptools==82.0.0
+urllib3==2.6.3
+zipp==3.23.0

--- a/batou/requirements.txt
+++ b/batou/requirements.txt
@@ -1,2 +1,4 @@
-batou @ https://github.com/flyingcircusio/batou/archive/f99d8dd9604edc336f7ae4424f751373c2db2ce9.zip#sha256=c5c1855c9ea96d82e1bb0275152077cfe2d47be32d159205de768bb4e007827b
+# appenv-python-preference: 3.12, 3.13
+# pre-release https://github.com/flyingcircusio/batou/pull/526
+batou @ https://github.com/flyingcircusio/batou/archive/eed3dc5274457cc2828cb5e6334f5c31ae1e719a.zip#sha256=29c18f5b963064ee8e2f0a69fbc4ff750b29d80882f9277fc713305a0d66d3ea
 # batou>=2.4.1


### PR DESCRIPTION
Update the base channel used by the batou deployment to current platform version.

Additionally, I improved the ability to use a dev-checkout of fc-nixos.