### PR TITLE
tests: update binary-generation to match fc-nixos value

### DIFF
--- a/src/fc/qemu/default.conf
+++ b/src/fc/qemu/default.conf
@@ -10,7 +10,7 @@ migration-address = tcp:127.0.0.2:{id}
 migration-ctl-address = 127.0.0.3:{id}
 migration-bandwidth = 0
 max-downtime = 2.0
-binary-generation = 1
+binary-generation = 3
 vm-max-total-memory = 0
 vm-expected-overhead = 512
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -346,7 +346,7 @@ def ceph_inst(request, ceph_mock):
         "swap_size": 1024 * 1024,
         "root_size": 1024 * 1024,
         "cidata_size": 1024 * 1024,
-        "binary_generation": 2,
+        "binary_generation": 3,
     }
     enc = {"parameters": {"environment_class_type": "nixos"}}
     ceph = Ceph(cfg, enc)

--- a/tests/hazmat/test_ceph.py
+++ b/tests/hazmat/test_ceph.py
@@ -359,8 +359,8 @@ partprobe args=/dev/rbd/rbd.hdd/simplevm.tmp machine=simplevm subsystem=ceph vol
 partprobe machine=simplevm returncode=0 subsystem=ceph volume=rbd.hdd/simplevm.tmp
 mount args="/dev/rbd/rbd.hdd/simplevm.tmp-part1" "/mnt/rbd/rbd.hdd/simplevm.tmp" machine=simplevm subsystem=ceph volume=rbd.hdd/simplevm.tmp
 mount machine=simplevm returncode=0 subsystem=ceph volume=rbd.hdd/simplevm.tmp
-guest-properties machine=simplevm properties={'binary_generation': 2} subsystem=ceph volume=rbd.hdd/simplevm.tmp
-binary-generation generation=2 machine=simplevm subsystem=ceph volume=rbd.hdd/simplevm.tmp
+guest-properties machine=simplevm properties={'binary_generation': 3} subsystem=ceph volume=rbd.hdd/simplevm.tmp
+binary-generation generation=3 machine=simplevm subsystem=ceph volume=rbd.hdd/simplevm.tmp
 umount args="/mnt/rbd/rbd.hdd/simplevm.tmp" machine=simplevm subsystem=ceph volume=rbd.hdd/simplevm.tmp
 umount machine=simplevm returncode=0 subsystem=ceph volume=rbd.hdd/simplevm.tmp
 pre-start machine=simplevm subsystem=ceph volume_spec=cidata
@@ -389,7 +389,7 @@ partprobe args=/dev/rbd/rbd.hdd/simplevm.cidata machine=simplevm subsystem=ceph 
 partprobe machine=simplevm returncode=0 subsystem=ceph volume=rbd.hdd/simplevm.cidata
 mount args="/dev/rbd/rbd.hdd/simplevm.cidata-part1" "/mnt/rbd/rbd.hdd/simplevm.cidata" machine=simplevm subsystem=ceph volume=rbd.hdd/simplevm.cidata
 mount machine=simplevm returncode=0 subsystem=ceph volume=rbd.hdd/simplevm.cidata
-guest-properties machine=simplevm properties={'binary_generation': 2} subsystem=ceph volume=rbd.hdd/simplevm.cidata
+guest-properties machine=simplevm properties={'binary_generation': 3} subsystem=ceph volume=rbd.hdd/simplevm.cidata
 umount args="/mnt/rbd/rbd.hdd/simplevm.cidata" machine=simplevm subsystem=ceph volume=rbd.hdd/simplevm.cidata
 umount machine=simplevm returncode=0 subsystem=ceph volume=rbd.hdd/simplevm.cidata
 rbd-status locker=None machine=simplevm subsystem=ceph volume=rbd.hdd/simplevm.root

--- a/tests/test_vm.py
+++ b/tests/test_vm.py
@@ -152,8 +152,8 @@ partprobe args=/dev/rbd/rbd.ssd/simplevm.tmp machine=simplevm subsystem=ceph vol
 partprobe machine=simplevm returncode=0 subsystem=ceph volume=rbd.ssd/simplevm.tmp
 mount args="/dev/rbd/rbd.ssd/simplevm.tmp-part1" "/mnt/rbd/rbd.ssd/simplevm.tmp" machine=simplevm subsystem=ceph volume=rbd.ssd/simplevm.tmp
 mount machine=simplevm returncode=0 subsystem=ceph volume=rbd.ssd/simplevm.tmp
-guest-properties machine=simplevm properties={'binary_generation': 2, 'rbd_pool': 'rbd.ssd'} subsystem=ceph volume=rbd.ssd/simplevm.tmp
-binary-generation generation=2 machine=simplevm subsystem=ceph volume=rbd.ssd/simplevm.tmp
+guest-properties machine=simplevm properties={'binary_generation': 3, 'rbd_pool': 'rbd.ssd'} subsystem=ceph volume=rbd.ssd/simplevm.tmp
+binary-generation generation=3 machine=simplevm subsystem=ceph volume=rbd.ssd/simplevm.tmp
 umount args="/mnt/rbd/rbd.ssd/simplevm.tmp" machine=simplevm subsystem=ceph volume=rbd.ssd/simplevm.tmp
 umount machine=simplevm returncode=0 subsystem=ceph volume=rbd.ssd/simplevm.tmp
 pre-start machine=simplevm subsystem=ceph volume_spec=cidata
@@ -182,7 +182,7 @@ partprobe args=/dev/rbd/rbd.ssd/simplevm.cidata machine=simplevm subsystem=ceph 
 partprobe machine=simplevm returncode=0 subsystem=ceph volume=rbd.ssd/simplevm.cidata
 mount args="/dev/rbd/rbd.ssd/simplevm.cidata-part1" "/mnt/rbd/rbd.ssd/simplevm.cidata" machine=simplevm subsystem=ceph volume=rbd.ssd/simplevm.cidata
 mount machine=simplevm returncode=0 subsystem=ceph volume=rbd.ssd/simplevm.cidata
-guest-properties machine=simplevm properties={'binary_generation': 2, 'rbd_pool': 'rbd.ssd'} subsystem=ceph volume=rbd.ssd/simplevm.cidata
+guest-properties machine=simplevm properties={'binary_generation': 3, 'rbd_pool': 'rbd.ssd'} subsystem=ceph volume=rbd.ssd/simplevm.cidata
 umount args="/mnt/rbd/rbd.ssd/simplevm.cidata" machine=simplevm subsystem=ceph volume=rbd.ssd/simplevm.cidata
 umount machine=simplevm returncode=0 subsystem=ceph volume=rbd.ssd/simplevm.cidata
 generate-config machine=simplevm
@@ -293,8 +293,8 @@ partprobe args=/dev/rbd/rbd.ssd/simplevm.tmp machine=simplevm subsystem=ceph vol
 partprobe machine=simplevm returncode=0 subsystem=ceph volume=rbd.ssd/simplevm.tmp
 mount args="/dev/rbd/rbd.ssd/simplevm.tmp-part1" "/mnt/rbd/rbd.ssd/simplevm.tmp" machine=simplevm subsystem=ceph volume=rbd.ssd/simplevm.tmp
 mount machine=simplevm returncode=0 subsystem=ceph volume=rbd.ssd/simplevm.tmp
-guest-properties machine=simplevm properties={'binary_generation': 2, 'rbd_pool': 'rbd.ssd'} subsystem=ceph volume=rbd.ssd/simplevm.tmp
-binary-generation generation=2 machine=simplevm subsystem=ceph volume=rbd.ssd/simplevm.tmp
+guest-properties machine=simplevm properties={'binary_generation': 3, 'rbd_pool': 'rbd.ssd'} subsystem=ceph volume=rbd.ssd/simplevm.tmp
+binary-generation generation=3 machine=simplevm subsystem=ceph volume=rbd.ssd/simplevm.tmp
 umount args="/mnt/rbd/rbd.ssd/simplevm.tmp" machine=simplevm subsystem=ceph volume=rbd.ssd/simplevm.tmp
 umount machine=simplevm returncode=0 subsystem=ceph volume=rbd.ssd/simplevm.tmp
 pre-start machine=simplevm subsystem=ceph volume_spec=cidata
@@ -321,7 +321,7 @@ partprobe args=/dev/rbd/rbd.ssd/simplevm.cidata machine=simplevm subsystem=ceph 
 partprobe machine=simplevm returncode=0 subsystem=ceph volume=rbd.ssd/simplevm.cidata
 mount args="/dev/rbd/rbd.ssd/simplevm.cidata-part1" "/mnt/rbd/rbd.ssd/simplevm.cidata" machine=simplevm subsystem=ceph volume=rbd.ssd/simplevm.cidata
 mount machine=simplevm returncode=0 subsystem=ceph volume=rbd.ssd/simplevm.cidata
-guest-properties machine=simplevm properties={'binary_generation': 2, 'rbd_pool': 'rbd.ssd'} subsystem=ceph volume=rbd.ssd/simplevm.cidata
+guest-properties machine=simplevm properties={'binary_generation': 3, 'rbd_pool': 'rbd.ssd'} subsystem=ceph volume=rbd.ssd/simplevm.cidata
 umount args="/mnt/rbd/rbd.ssd/simplevm.cidata" machine=simplevm subsystem=ceph volume=rbd.ssd/simplevm.cidata
 umount machine=simplevm returncode=0 subsystem=ceph volume=rbd.ssd/simplevm.cidata
 generate-config machine=simplevm


### PR DESCRIPTION
In fc-nixos, the binary-generation value has been bumped 2 -> 3. https://github.com/flyingcircusio/fc-nixos/pull/2351

Unfortunately, the test setup is a bit codependent here: When the fc.qemu tests are run as a NixOS test, they get configuration overrides from the platform role. So changes in fc-nixos need to be reflected here as well, at least as a simple stopgap adjustment.

PL-135278