### PR TITLE
Pl 131408 migration compat

### DIFF
--- a/src/fc/qemu/incoming.py
+++ b/src/fc/qemu/incoming.py
@@ -160,15 +160,18 @@ class IncomingServer(object):
 
     def screen_config(self, config):
         """Remove obsolete items from transferred Qemu config."""
-        # Remove old IOMMU usage
-        config = re.sub(r"^\s*iommu\s*=.*$", "", config, flags=re.M)
-        # Update old qmp monitor snippet
-        config = re.sub(
-            r'^\s*chardev\s*=\s*"ch_qmp_monitor"\n\s*default\s*=\s*"on"$',
-            r'  chardev = "ch_qmp_monitor"\n  pretty = "off"',
-            config,
-            flags=re.M,
+        # There are currently no config changes necessary for the versions in
+        # use. This is just a placeholder to demonstrate and check functionality
+        # of the mechanism in tests.
+        config, count = re.subn(
+            r"^\s*MYMAGICFEATURE\s*=.*$", "", config, flags=re.M
         )
+        if count:
+            self.log.info(
+                "screen-config-rewrite",
+                rule="strip-mymagicfeature",
+                count=count,
+            )
         return config
 
     def screen_args(self, args):

--- a/src/fc/qemu/incoming.py
+++ b/src/fc/qemu/incoming.py
@@ -171,11 +171,50 @@ class IncomingServer(object):
         )
         return config
 
+    def screen_args(self, args):
+        """Translate obsolete CLI args from older fc.qemu/Qemu senders.
+
+        Each rewrite pattern shall be grouped and annotated by the qemu versions
+        affected, and can be removed in later versions when the migration has
+        happened.
+        """
+        result = []
+        for arg in args:
+            match arg.split(" ", 1):
+                # Qemu 10.0 removed `-chroot DIR` and `-runas USER`
+                # (deprecated in 9.0). Replacement: `-run-with
+                # chroot=DIR` and `-run-with user=USER`. Senders
+                # running fc.qemu with Qemu <= 6.x still emit the old
+                # form.
+                case ["-chroot", value]:
+                    rewritten = f"-run-with chroot={value}"
+                    self.log.info(
+                        "screen-args-rewrite",
+                        rule="chroot-to-run-with",
+                        before=arg,
+                        after=rewritten,
+                    )
+                    result.append(rewritten)
+                case ["-runas", value]:
+                    rewritten = f"-run-with user={value}"
+                    self.log.info(
+                        "screen-args-rewrite",
+                        rule="runas-to-run-with",
+                        before=arg,
+                        after=rewritten,
+                    )
+                    result.append(rewritten)
+                # TODO: Qemu 10.x ++: `-readconfig` is deprecated and will need
+                # to be rewritten at the next major update
+                case _:
+                    result.append(arg)
+        return result
+
     def prepare_incoming(self, args, config):
-        self.qemu.args = args
+        self.qemu.args = self.screen_args(args)
         # Adapt actual VM memory size: we will start with the proper parameter
         # but the memory verification needs to find the real value.
-        for arg in args:
+        for arg in self.qemu.args:
             if arg.startswith("-m "):
                 # XXX This is a nasty code path.
                 memory = int(arg.split(" ")[1])

--- a/tests/test_incoming.py
+++ b/tests/test_incoming.py
@@ -69,46 +69,6 @@ def test_screen_config_disable_iommu(mock_agent):
     )
 
 
-def test_screen_config_update_qmp_monitor_syntax(mock_agent):
-    s = IncomingServer(mock_agent)
-    assert (
-        s.screen_config(
-            """\
-
-# QMP monitor support via Unix socket
-
-[mon "qmp_monitor"]
-  mode = "control"
-  chardev = "ch_qmp_monitor"
-  default = "on"
-
-[chardev "ch_qmp_monitor"]
-  backend = "socket"
-  path = "/run/qemu.{name}.qmp.sock"
-  server = "on"
-  wait = "off"
-
-"""
-        )
-        == """\
-
-# QMP monitor support via Unix socket
-
-[mon "qmp_monitor"]
-  mode = "control"
-  chardev = "ch_qmp_monitor"
-  pretty = "off"
-
-[chardev "ch_qmp_monitor"]
-  backend = "socket"
-  path = "/run/qemu.{name}.qmp.sock"
-  server = "on"
-  wait = "off"
-
-"""
-    )
-
-
 def test_screen_args_rewrites_chroot_and_runas(mock_agent):
     s = IncomingServer(mock_agent)
     assert s.screen_args(

--- a/tests/test_incoming.py
+++ b/tests/test_incoming.py
@@ -54,7 +54,7 @@ def test_screen_config_disable_iommu(mock_agent):
             """\
 [machine]
   type = "pc-i440fx-2.5"
-  iommu = "off"
+  MYMAGICFEATURE = "placeholder"
   accel = "kvm"
 
 """
@@ -107,3 +107,31 @@ def test_screen_config_update_qmp_monitor_syntax(mock_agent):
 
 """
     )
+
+
+def test_screen_args_rewrites_chroot_and_runas(mock_agent):
+    s = IncomingServer(mock_agent)
+    assert s.screen_args(
+        [
+            "-nodefaults",
+            "-chroot /srv/vm/test72",
+            "-runas nobody",
+            "-vga std",
+        ]
+    ) == [
+        "-nodefaults",
+        "-run-with chroot=/srv/vm/test72",
+        "-run-with user=nobody",
+        "-vga std",
+    ]
+
+
+def test_screen_args_passes_modern_args_through(mock_agent):
+    s = IncomingServer(mock_agent)
+    args = [
+        "-nodefaults",
+        "-run-with chroot=/srv/vm/test72",
+        "-run-with user=nobody",
+        "-vga std",
+    ]
+    assert s.screen_args(args) == args


### PR DESCRIPTION
qemu-10.x has removed the `-chroot` and `-runas` CLI args. As during
live migration we usually sent the args of the old process and reuse
them, these incompatible args need to be replaced similar as done with
screen_config already.

Doing replacements just in an upwards compatible direction is fine,
because we do not intend to run with a mixed-version KVM cluster for
longer than the rollout period.

PL-131408

Tested:
- [x] in development clusters, incoming migrations work successfully.
- [x] testsuite passes