### PR TITLE
fc-qemu maintenance enter: fix qemu process matching

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,6 +4,15 @@ Release notes
 1.8 (unreleased)
 ----------------
 
+- fc-qemu maintenance enter: fix VM counting under qemu 10.1 (PL-131408)
+
+    Refactor VM process counting from pgrep to python psutils and a wider
+    bunch of heuristic patterns.
+    qemu 10.x no longer rewrites argv[0] to the absolute path of the
+    qemu binary, so the path-anchored pgrep pattern from PL-130990
+    matched nothing and maintenance would proceed while VMs were still
+    running.
+
 - Update qemu to 10.1; drop 6.0 (PL-131408)
 
   Includes code and test match adjustments to work with qemu-10.1.

--- a/src/fc/qemu/agent.py
+++ b/src/fc/qemu/agent.py
@@ -12,6 +12,7 @@ import subprocess
 import sys
 import time
 import typing
+from dataclasses import dataclass
 from ipaddress import ip_interface
 from multiprocessing.pool import ThreadPool
 from pathlib import Path
@@ -34,7 +35,11 @@ from .exc import (
 )
 from .hazmat.ceph import Ceph
 from .hazmat.cpuscan import scan_cpus
-from .hazmat.qemu import Qemu, detect_current_machine_type
+from .hazmat.qemu import (
+    Qemu,
+    detect_current_machine_type,
+    get_running_qemu_processes,
+)
 from .incoming import IncomingServer
 from .outgoing import Outgoing
 from .sysconfig import sysconfig
@@ -592,13 +597,7 @@ class Agent(object):
             sysconfig.agent["maintenance_evacuation_timeout"], interval=3
         )
         while timeout.tick():
-            process = subprocess.Popen(
-                ["pgrep", "-f", "^[^ ]*/qemu-system-x86_64"],
-                stdout=subprocess.PIPE,
-            )
-            process.wait()
-            assert process.stdout is not None
-            num_procs = len(process.stdout.read().splitlines())
+            num_procs = len(get_running_qemu_processes())
             log.info(
                 "evacuation-running",
                 vms=num_procs,
@@ -609,6 +608,7 @@ class Agent(object):
                 # maintenance.
                 log.info("evacuation-success")
                 sys.exit(0)
+
             time.sleep(10)
 
         log.info("evacuation-timeout", action="retry maintenance")

--- a/src/fc/qemu/hazmat/qemu.py
+++ b/src/fc/qemu/hazmat/qemu.py
@@ -110,6 +110,49 @@ def locked_global(f):
     return locked
 
 
+def is_qemu_proc(name: str, cmd_proc: str, exe: str) -> bool:
+    if name.startswith("kvm."):
+        return True
+    if cmd_proc == "qemu-system-x86_64":  # qemu-10.0
+        return True
+    if cmd_proc.endswith("/qemu-system-x86_64"):  # qemu-6.0
+        return True
+    if exe.endswith("/.qemu-system-x86_64-wrapped"):  # qemu-10.0
+        return True
+    if exe.endswith("/qemu-system-x86_64"):  # qemu-6.0
+        return True
+    return False
+
+
+def pinfo_is_qemu_proc(
+    psutil_proc_info: dict[str, str | list[str] | int | None],
+) -> bool:
+    """
+    Expected input: dict with (at least) keys "name", "exe", "cmdline"
+
+    Wrapper to extract normalised attributes.
+    psutil.Process.as_dict() returns `None` for attributes it could not
+    retrieve (AccessDenied, zombie, transient process). Extract and normalise
+    the plain strings used by the detection heuristics.
+    """
+    name = psutil_proc_info["name"] or ""
+    exe = psutil_proc_info["exe"] or ""
+    cmdline = psutil_proc_info["cmdline"] or []
+    cmdline_proc = cmdline[0] if cmdline else ""
+    return is_qemu_proc(name, cmdline_proc, exe)
+
+
+def get_running_qemu_processes() -> list[psutil.Process]:
+    """Functional requirement: detect still running VM processes to have a
+    safe-guard for entering maintenance only without running VMs.
+
+    Cosmetic requirement: count each VM only once. Each running VM has the
+    actual qemu process plus a python `supervised-qemu` parent.
+    """
+    procs = psutil.process_iter(attrs=["pid", "name", "exe", "cmdline"])
+    return [p for p in procs if pinfo_is_qemu_proc(p.info)]
+
+
 class Qemu(object):
     prefix = Path("/")
     executable = "qemu-system-x86_64"
@@ -253,35 +296,26 @@ class Qemu(object):
             alternate = log_dir / f"{self.name}-{alt_marker}.log"
             log_file.rename(alternate)
 
+    # XXX: It might make sense to unify the matching logic here with
+    # agent.py:KvmHostProcess
     def _current_vms_booked_memory(self):
         """Determine the amount of booked memory (MiB) from the
 
         currently running VM processes.
         """
         total = 0
-        for proc in psutil.process_iter():
+        for proc in get_running_qemu_processes():
             try:
-                pinfo = proc.as_dict(attrs=["pid", "name", "cmdline"])
-            except psutil.NoSuchProcess:
-                continue
-
-            if not pinfo["name"].startswith("kvm."):
-                continue
-            if not (
-                pinfo["cmdline"] and pinfo["cmdline"][0] == "qemu-system-x86_64"
-            ):
-                continue
-            try:
-                m_flag = pinfo["cmdline"].index("-m")
-                memory = int(pinfo["cmdline"][m_flag + 1])
+                m_flag = proc.info["cmdline"].index("-m")
+                memory = int(proc.info["cmdline"][m_flag + 1])
             except (ValueError, KeyError):
                 self.log.debug(
                     "unexpected-cmdline",
-                    cmdline=format(" ".join(pinfo["cmdline"])),
+                    cmdline=format(" ".join(proc.info["cmdline"])),
                 )
                 raise ControlledRuntimeException(
                     "Can not determine used memory for {}".format(
-                        " ".join(pinfo["cmdline"])
+                        " ".join(proc.info["cmdline"])
                     )
                 )
             total += memory + self.vm_expected_overhead

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -424,9 +424,12 @@ def clean_rbd_pools(request, kill_vms, ceph_mock):
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
             ) as proc:
-                stdout, stderr = proc.communicate(
-                    timeout=5
-                )  # Add timeout for safety
+                try:
+                    # Add timeout for safety
+                    stdout, stderr = proc.communicate(timeout=5)
+                except subprocess.TimeoutExpired:
+                    proc.kill()
+                    raise
             for line in stdout.splitlines():
                 image = line.strip().decode("ascii")
                 if not image or "-" in image:  # empty line or base image

--- a/tests/hazmat/test_qemu.py
+++ b/tests/hazmat/test_qemu.py
@@ -1,6 +1,13 @@
+from unittest.mock import Mock
+
 import pytest
 
-from fc.qemu.hazmat.qemu import Qemu
+from fc.qemu.hazmat.qemu import (
+    Qemu,
+    get_running_qemu_processes,
+    is_qemu_proc,
+    pinfo_is_qemu_proc,
+)
 
 
 def test_write_file_expects_bytes(guest_agent):
@@ -122,3 +129,119 @@ def test_detect_current_machine_type_not_found(mock_machine_help):
 
     with pytest.raises(KeyError):
         detect_current_machine_type("nonexistent")
+
+
+QEMU10_PROCS = [
+    {
+        "cmdline": [
+            "/nix/store/60m4rxhg2fldqaak400c0lry96ijrzqn-python3-3.13.13/bin/python3.13",
+            "/nix/store/kxr6dfmbzbnyi8vyxm1g5m33j51c4fbc-python3.13-fc.qemu-1.8dev/bin/.supervised-qemu-wrapped",
+            "qemu-system-x86_64 -nodefaults -only-migratable -cpu "
+            "Nehalem-v2,spec-ctrl,ssbd,enforce -name "
+            "slurmtest13,process=kvm.slurmtest13 -run-with "
+            "chroot=/srv/vm/slurmtest13 -run-with user=nobody -serial "
+            "file:/var/log/vm/slurmtest13.log -display vnc=127.0.0.1:6891 "
+            "-pidfile /run/qemu.slurmtest13.pid -vga std -m 3072 -readconfig "
+            "/run/qemu.slurmtest13.cfg -incoming tcp:172.20.4.110:6891 -D "
+            "/var/log/vm/slurmtest13.qemu.internal.log",
+            "slurmtest13",
+            "/var/log/vm/slurmtest13.supervisor.log",
+        ],
+        "exe": "/nix/store/60m4rxhg2fldqaak400c0lry96ijrzqn-python3-3.13.13/bin/python3.13",
+        "name": ".supervised-qem",
+        "pid": 764110,
+    },
+    {
+        "cmdline": [
+            "qemu-system-x86_64",
+            "-nodefaults",
+            "-only-migratable",
+            "-cpu",
+            "Nehalem-v2,spec-ctrl,ssbd,enforce",
+            "-name",
+            "slurmtest13,process=kvm.slurmtest13",
+            "-run-with",
+            "chroot=/srv/vm/slurmtest13",
+            "-run-with",
+            "user=nobody",
+            "-serial",
+            "file:/var/log/vm/slurmtest13.log",
+            "-display",
+            "vnc=127.0.0.1:6891",
+            "-pidfile",
+            "/run/qemu.slurmtest13.pid",
+            "-vga",
+            "std",
+            "-m",
+            "3072",
+            "-readconfig",
+            "/run/qemu.slurmtest13.cfg",
+            "-incoming",
+            "tcp:172.20.4.110:6891",
+            "-D",
+            "/var/log/vm/slurmtest13.qemu.internal.log",
+        ],
+        "exe": "/nix/store/391smsk8nghkg17g5dd5dn2cdb6lkhlm-qemu-10.2.2/bin/.qemu-system-x86_64-wrapped",
+        "name": "kvm.slurmtest13",
+        "pid": 764111,
+    },
+    {"cmdline": [], "exe": "", "name": "kvm-pit/764111", "pid": 764220},
+    {"cmdline": [], "exe": "", "name": "kworker/4:2H-kblockd", "pid": 811535},
+    {
+        "cmdline": [
+            "/nix/store/60m4rxhg2fldqaak400c0lry96ijrzqn-python3-3.13.13/bin/python3.13",
+            "/nix/store/37cnh63ah3ly5vlb89l65xk74w2xb85i-python3.13-fc.qemu-1.8dev/bin/.fc-qemu-wrapped",
+            "maintenance",
+            "enter",
+        ],
+        "exe": "/nix/store/60m4rxhg2fldqaak400c0lry96ijrzqn-python3-3.13.13/bin/python3.13",
+        "name": ".fc-qemu-wrappe",
+        "pid": 134674,
+    },
+]
+
+
+def test_get_running_qemu_processes(monkeypatch):
+
+    processes = []
+    for p in QEMU10_PROCS:
+        mock_process = Mock()
+        mock_process.info = p
+        processes.append(mock_process)
+
+    monkeypatch.setattr("psutil.process_iter", lambda *a, **kw: processes)
+
+    assert len(get_running_qemu_processes()) == 1
+
+
+def test_is_qemu_proc():
+    assert is_qemu_proc(
+        "kvm.somevm",
+        "qemu-system-x86_64",
+        "/nix/store/asdf-qemu/bin/qemu-system-x86_64",
+    )
+    assert not is_qemu_proc("", "", "")
+    assert not is_qemu_proc(".fc-qemu-wrappe", "python3.13", "python3.13")
+    assert not is_qemu_proc("kvm-pit", "", "")
+    assert is_qemu_proc("kvm.somevm", "", "")
+    # qemu-6.0 specific behaviour
+    assert is_qemu_proc("", "/nix/store/asdf-qemu/bin/qemu-system-x86_64", "")
+    assert is_qemu_proc("", "", "/nix/store/asdf-qemu/bin/qemu-system-x86_64")
+    # qemu-10.0+ specific behaviour
+    assert is_qemu_proc("", "qemu-system-x86_64", "")
+    assert is_qemu_proc(
+        "", "", "/nix/store/asdf-qemu-10.2.2/bin/.qemu-system-x86_64-wrapped"
+    )
+
+
+def test_pinfo_is_qemu_proc_normalises_unexpected_data():
+    assert not pinfo_is_qemu_proc(
+        {"name": "somekernelthread", "cmdline": [], "exe": None, "pid": 1932}
+    )
+    assert not pinfo_is_qemu_proc(
+        {
+            "name": ".fc-qemu-wrappe",
+            "cmdline": ["python3.13", ".fc-qemu-wrapped", "qemu-system-x86_64"],
+            "exe": None,
+        }
+    )

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -9,7 +9,11 @@ import pytest
 import fc.qemu.util as util
 from fc.qemu.agent import Agent, iproute2_json
 from fc.qemu.exc import EnvironmentChanged, VMStateInconsistent
-from fc.qemu.hazmat.qemu import Qemu, detect_current_machine_type
+from fc.qemu.hazmat.qemu import (
+    Qemu,
+    detect_current_machine_type,
+    get_running_qemu_processes,
+)
 
 
 def named_vm_cfg(name, monkeypatch):
@@ -157,6 +161,31 @@ def test_maintenance():
     with pytest.raises(SystemExit, match="0"):
         Agent.maintenance_enter()
     Agent.maintenance_leave()
+
+
+@pytest.mark.live
+def test_live_count_running_qemu_processes(vm, vm_with_pub):
+    ####
+    # WARNING!
+    # If this test ever fails with new platform or qemu versions, keep in mind
+    # the migration scenarios of old VM processes when adjusting the process
+    # match heuristics! Still need to match old process patterns!
+    ###
+
+    # Each running VM has a real qemu process plus a python
+    # `supervised-qemu` parent; the helper must count only the qemu
+    # processes regardless of whether qemu rewrites argv[0] to its
+    # absolute path (qemu 6.x) or leaves it as the bare basename
+    # (qemu 10.x). PL-130990, PL-134257.
+    assert len(get_running_qemu_processes()) == 0
+    vm.start()
+    assert len(get_running_qemu_processes()) == 1
+    vm_with_pub.start()
+    assert len(get_running_qemu_processes()) == 2
+    vm_with_pub.stop()
+    assert len(get_running_qemu_processes()) == 1
+    vm.stop()
+    assert len(get_running_qemu_processes()) == 0
 
 
 def test_ensure_lock_contention_returns_ex_tempfail(

--- a/tests/test_binenv.py
+++ b/tests/test_binenv.py
@@ -14,7 +14,6 @@ REQUIRED_BINARIES = set(
         "mount",
         "parted",
         "partprobe",
-        "pgrep",
         "qemu-system-x86_64",
         "rbd",
         "rbd-locktool",


### PR DESCRIPTION
Due to changes between qemu-6.0 and qemu-10.1, `qemu-system-x86_64` do not appear as absolute paths anymore in the process list, breaking the `pgrep` regex match. Consequentially, VMs did not always evacuate before shutting down the server.

`^[^ ]*qemu-system-x86_64 ` drops the mandatory /. The leading `[^ ]*` still absorbs an optional path prefix
  (or nothing) without crossing a space, and the trailing space
guarantees the basename was the whole argv[0] token,
  not a substring.

- qemu 6.0 cmdline `/nix/store/…/qemu-system-x86_64 -nodefaults …` → `[^ ]*` matches the nix path, then the literal matches. ✓
- qemu 10.1 cmdline `qemu-system-x86_64 -nodefaults …` → `[^ ]*` matches empty, then the literal matches. ✓
- Python supervisor cmdline `/nix/store/…/python3.13 /nix/store/…/.supervised-qemu-wrapped qemu-system-x86_64 …` → `^[^ ]*` is anchored to the start and stops at the first space after `python3.13`; that token doesn't end in qemu-system-x86_64, so no match. ✓ VMs are not counted twice.

## security considerations

- verified behaviour on development host (qemu10)
- manually verified pgrep matching on legacy host with qemu-6.0
- added integration test to monitor for future drift in matching